### PR TITLE
Add support for the Seel Series Arctis Pro 2019 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 - Logitech G533
 - Logitech G430 (Last working on macOS in commit 41be99379f)
 - SteelSeries Arctis 7
-
+- SteelSeries Arctis Pro 2019 Edition
 
 ### Other Features
 

--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -8,11 +8,12 @@
 #include "devices/logitech_g633.h"
 #include "devices/logitech_g930.h"
 #include "devices/steelseries_arctis7.h"
+#include "devices/steelseries_arctispro_2019.h"
 
 #include <string.h>
 
 
-#define NUMDEVICES 8
+#define NUMDEVICES 9
 // array of pointers to device
 static struct device *(devicelist[NUMDEVICES]);
 
@@ -26,6 +27,7 @@ void init_devices()
     g633_init(&devicelist[5]);
     g930_init(&devicelist[6]);
     arctis7_init(&devicelist[7]);
+    arctispro_2019_init(&devicelist[8]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -15,4 +15,6 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis7.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis7.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctispro_2019.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctispro_2019.h
     PARENT_SCOPE)

--- a/src/devices/steelseries_arctispro_2019.c
+++ b/src/devices/steelseries_arctispro_2019.c
@@ -1,0 +1,57 @@
+#include "../device.h"
+#include "../utility.h"
+
+#include <hidapi.h>
+#include <string.h>
+#include <stdlib.h>
+
+static struct device device_arctispro_2019;
+
+static int arctispro_2019_send_sidetone(hid_device *device_handle, uint8_t num);
+
+void arctispro_2019_init(struct device** device)
+{
+    device_arctispro_2019.idVendor = VENDOR_STEELSERIES;
+    device_arctispro_2019.idProduct = 0x1252;
+    device_arctispro_2019.idInterface = 0x05;
+
+    strcpy(device_arctispro_2019.device_name, "Steel Series Arctis Pro 2019");
+
+    device_arctispro_2019.capabilities = CAP_SIDETONE;
+    device_arctispro_2019.send_sidetone = &arctispro_2019_send_sidetone;
+
+    *device = &device_arctispro_2019;
+}
+
+static int arctispro_2019_send_sidetone(hid_device *device_handle, uint8_t num)
+{
+    int ret = -1;
+
+    // the range of the Arctis pro 2019 seems to be the same as the 7 - 0 to 0x12 (18)
+    num = map(num, 0, 128, 0x00, 0x12);
+
+    unsigned char *buf = calloc(31, 1);
+
+    if (!buf)
+    {
+        return ret;
+    }
+
+    const unsigned char data_on[5] = {0x06, 0x35, 0x01, 0x00, num};
+    const unsigned char data_off[2] = {0x06, 0x35};
+
+    if (num)
+    {
+        memmove(buf, data_on, sizeof(data_on));
+    }
+    else
+    {
+        memmove(buf, data_off, sizeof(data_off));
+    }
+
+    ret = hid_write(device_handle, buf, 31);
+
+    SAFE_FREE(buf);
+
+    return ret;
+}

--- a/src/devices/steelseries_arctispro_2019.h
+++ b/src/devices/steelseries_arctispro_2019.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void arctispro_2019_init(struct device** device);

--- a/udev/50-steelseries-arctis-pro-2019.rules
+++ b/udev/50-steelseries-arctis-pro-2019.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1252", MODE="0666"


### PR DESCRIPTION
This adds support for the Steel Series Arctis Pro 2019 edition (The wired usb one without a dac). Tested on Manjaro.