### PR TITLE
Corsair Void (pro) should return HSC_ERROR when disconnected

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -72,7 +72,7 @@ struct device
      *                          device as defined here (same ids)
      *
      *  @returns    >= 0            battery level (in %)
-     *              BATTERY_LOADING when the battery is currently being loaded
+     *              BATTERY_CHARGING when the battery is currently being loaded
      *              -1              HIDAPI error
      */
     int (*request_battery)(hid_device *hid_device);


### PR DESCRIPTION
Return `HSC_ERROR` when the headset is disconnected, just like it's done for the [Logitech g533](https://github.com/Sapd/HeadsetControl/blob/master/src/devices/logitech_g533.c#L67).

Alternatively, add a new `DISCONNECTED` state?