### PR TITLE
udev: give rights only to seated user

### DIFF
--- a/udev/50-corsair-void-elite.rules
+++ b/udev/50-corsair-void-elite.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a55", MODE="0666"

--- a/udev/50-corsair-void-pro-usb.rules
+++ b/udev/50-corsair-void-pro-usb.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a17", MODE="0666"

--- a/udev/50-corsair-void-pro.rules
+++ b/udev/50-corsair-void-pro.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a14", MODE="0666"

--- a/udev/50-corsair-void.rules
+++ b/udev/50-corsair-void.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1b27", MODE="0666"

--- a/udev/50-corsair_void_rgb_usb.rules
+++ b/udev/50-corsair_void_rgb_usb.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1b2a", MODE="0666"

--- a/udev/50-logitech-g430.rules
+++ b/udev/50-logitech-g430.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="0a4d", MODE="0666"

--- a/udev/50-logitech-g533.rules
+++ b/udev/50-logitech-g533.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="0a66", MODE="0666"

--- a/udev/50-logitech-g633.rules
+++ b/udev/50-logitech-g633.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="0a5c", MODE="0666"

--- a/udev/50-logitech-g930.rules
+++ b/udev/50-logitech-g930.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="0a1f", MODE="0666"

--- a/udev/50-logitech-g933.rules
+++ b/udev/50-logitech-g933.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a5b", MODE="0666"

--- a/udev/50-logitech-g935.rules
+++ b/udev/50-logitech-g935.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a87", MODE="0666"

--- a/udev/50-steelseries-arctis-7-2019.rules
+++ b/udev/50-steelseries-arctis-7-2019.rules
@@ -1,1 +1,0 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="12ad", MODE="0666"

--- a/udev/50-steelseries-arctis-7.rules
+++ b/udev/50-steelseries-arctis-7.rules
@@ -1,1 +1,0 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1260", MODE="0666"

--- a/udev/50-steelseries-arctis-pro-2019.rules
+++ b/udev/50-steelseries-arctis-pro-2019.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1252", MODE="0666"

--- a/udev/70-headsets.rules
+++ b/udev/70-headsets.rules
@@ -1,0 +1,45 @@
+ACTION!="add|change", GOGO="headset_end"
+
+# Corair VOID ELITE
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a55", TAG+="uaccess"
+
+# Corsair VOID PRO
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a14", TAG+="uaccess"
+
+# Corsair VOID PRO USB
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a17", TAG+="uaccess"
+
+# Corsair VOID RGB USB
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1b2a", TAG+="uaccess"
+
+# Corsair VOID
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1b27", TAG+="uaccess"
+
+# Logitech G430
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a4d", TAG+="uaccess"
+
+# Logitech G533
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a66", TAG+="uaccess"
+
+# logitech G633
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a5c", TAG+="uaccess"
+
+# logitech G930
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a1f", TAG+="uaccess"
+
+# logitech G933
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a5b", TAG+="uaccess"
+
+# logitech G935
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a87", TAG+="uaccess"
+
+# SteelSeries ACTIS 7 (2019)
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="12ad", TAG+="uaccess"
+
+# SteelSeries ARCTIS 7
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1260", TAG+="uaccess"
+
+# SteelSeries ARCTIS PRO (2019)
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1252", TAG+="uaccess"
+
+LABEL="headset_end"


### PR DESCRIPTION
The `uaccess` udev TAG allows to dynamically set permission to
physically connected users thus we can avoid giving RAW access to the
devices to everyone.

Note: I also merged the rules into a single file for simplicity and moved it from `50-*` to `70-*` because it is the norm used in multiple projects settings hidraw permissions.