### PR TITLE
Add battery status for G930

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 - Logitech G533
   - Sidetone, Battery (for Wireless)
 - Logitech G930
-  - Sidetone
+  - Sidetone, Battery
 - Logitech G633 / G933 / G935
   - Sidetone, Battery (for Wireless), LED on/off
 - SteelSeries Arctis (7 and Pro)

--- a/src/devices/logitech_g930.c
+++ b/src/devices/logitech_g930.c
@@ -1,12 +1,25 @@
 #include "../device.h"
+#include "logitech.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <hidapi.h>
 #include <string.h>
+
+#include <errno.h>
+
+#define BATTERY_MAX 91
+#define BATTERY_MIN 44
+#define MSG_SIZE    64
 
 static struct device device_g930;
 
 static const uint16_t PRODUCT_ID = 0x0a1f;
 
 static int g930_send_sidetone(hid_device* device_handle, uint8_t num);
+static int g930_request_battery(hid_device* device_handle);
 
 void g930_init(struct device** device)
 {
@@ -18,19 +31,57 @@ void g930_init(struct device** device)
 
     strncpy(device_g930.device_name, "Logitech G930", sizeof(device_g930.device_name));
 
-    device_g930.capabilities = CAP_SIDETONE;
+    device_g930.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS;
     device_g930.send_sidetone = &g930_send_sidetone;
+    device_g930.request_battery = &g930_request_battery;
 
     *device = &device_g930;
 }
 
 static int g930_send_sidetone(hid_device* device_handle, uint8_t num)
 {
-#define MSG_SIZE 64
     uint8_t data[MSG_SIZE] = { 0xFF, 0x0A, 0, 0xFF, 0xF4, 0x10, 0x05, 0xDA, 0x8F, 0xF2, 0x01, num, 0, 0, 0, 0 };
 
     for (int i = 16; i < MSG_SIZE; i++)
         data[i] = 0;
 
     return hid_send_feature_report(device_handle, data, MSG_SIZE);
+}
+
+static int g930_request_battery(hid_device* device_handle)
+{
+    /*
+        CREDIT GOES TO https://github.com/Roliga for the project
+        https://github.com/Roliga/g930-battery-percentage/blob/master/main.c
+        I've simply ported that implementation to this project!
+    */
+
+    int i;
+    int res;
+
+    unsigned char buf[MSG_SIZE] = { 0xFF, 0x09, 0x00, 0xFD, 0xF4, 0x10, 0x05, 0xB1, 0xBF, 0xA0, 0x04 };
+    for (i = 11; i < MSG_SIZE; i++)
+        buf[i] = 0;
+
+    res = hid_send_feature_report(device_handle, buf, MSG_SIZE);
+    if (res < 0) {
+        fprintf(stderr, "Failed to send feature report: %ls\n", hid_error(device_handle));
+        return -1;
+    }
+
+    for (i = 0; i < 3; i++) {
+        res = hid_get_feature_report(device_handle, buf, MSG_SIZE);
+
+        if (res < 0) {
+            fprintf(stderr, "Failed to get feature report %d: %ls\n", i, hid_error(device_handle));
+            return -1;
+        }
+
+        if (i < 2) {
+            usleep(100000);
+        }
+    }
+    unsigned int batteryPercent = (buf[13] - BATTERY_MIN) * 100 / (BATTERY_MAX - BATTERY_MIN);
+
+    return (int)(batteryPercent);
 }


### PR DESCRIPTION
I simply ported (copied actually) it from https://github.com/Roliga/g930-battery-percentage

Seems to work quite good. 

Issues:
- Charging status is not read from the device
- Runtime / Charge time is not read
- During Charge, battery goes over 100%

I believe the code directly reads the voltage, maybe someone can improve that in a later step.

This is my first pullrequest, is everything in order? 