### PR TITLE
Fix invalid GOGO in udev rules

### DIFF
--- a/udev/70-headsets.rules
+++ b/udev/70-headsets.rules
@@ -1,4 +1,4 @@
-ACTION!="add|change", GOGO="headset_end"
+ACTION!="add|change", GOTO="headset_end"
 
 # Corair VOID ELITE
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a55", TAG+="uaccess"


### PR DESCRIPTION
Should probably be "GOTO" here.