### PR TITLE
Add capabilitiy for setting inactive time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+.idea/
+cmake-build-debug/

--- a/src/device.h
+++ b/src/device.h
@@ -15,6 +15,7 @@ enum capabilities {
     CAP_BATTERY_STATUS = 2,
     CAP_NOTIFICATION_SOUND = 4,
     CAP_LIGHTS = 8,
+    CAP_INACTIVE_TIME = 16
 };
 
 /** @brief Flags for battery status
@@ -105,4 +106,20 @@ struct device {
      *              -1          HIDAPI error
      */
     int (*switch_lights)(hid_device* hid_device, uint8_t on);
+
+    /** @brief Function pointer for setting headset inactive time
+     *
+     *  Forwards the request to the device specific implementation
+     *
+     *  @param  device_handle   The hidapi handle. Must be the same
+     *                          device as defined here (same ids)
+     *  @param  num             Number of minutes after which the device
+     *                          is turned off, between 0 - 90,
+     *                          0 disables the automatic shutdown feature
+     *
+     *  @returns    > 0         on success
+     *              HSC_ERROR   on error specific to this software
+     *              -1          HIDAPI error
+     */
+    int (*send_inactive_time)(hid_device* hid_device, uint8_t num);
 };

--- a/src/devices/steelseries_arctis.c
+++ b/src/devices/steelseries_arctis.c
@@ -100,25 +100,13 @@ static int arctis_request_battery(hid_device* device_handle)
 
 static int arctis_send_inactive_time(hid_device* device_handle, uint8_t num)
 {
-    int ret = -1;
-
     // as the value is in minutes, mapping to a different range does not make too much sense here
     // the range of the Arctis 7 seems to be from 0 to 0x5A (90)
     // num = map(num, 0, 128, 0x00, 0x5A);
 
-    unsigned char* buf = calloc(31, 1);
+    uint8_t data[31] = { 0x06, 0x51, num };
 
-    if (!buf) {
-        return ret;
-    }
-
-    const unsigned char data[3] = { 0x06, 0x51, num };
-
-    memmove(buf, data, sizeof(data));
-
-    ret = hid_write(device_handle, buf, 31);
-
-    free(buf);
+    int ret = hid_write(device_handle, data, 31);
 
     if(ret >= 0) {
         ret = arctis_save_state(device_handle);
@@ -128,21 +116,7 @@ static int arctis_send_inactive_time(hid_device* device_handle, uint8_t num)
 }
 
 int arctis_save_state(hid_device* device_handle) {
-    int ret = -1;
+    uint8_t data[31] = { 0x06, 0x09 };
 
-    unsigned char* buf = calloc(31, 1);
-
-    if (!buf) {
-        return ret;
-    }
-
-    const unsigned char data[2] = { 0x06, 0x09 };
-
-    memmove(buf, data, sizeof(data));
-
-    ret = hid_write(device_handle, buf, 31);
-
-    free(buf);
-
-    return ret;
+    return hid_write(device_handle, data, 31);
 }

--- a/src/devices/steelseries_arctis.c
+++ b/src/devices/steelseries_arctis.c
@@ -17,6 +17,8 @@ static int arctis_send_sidetone(hid_device* device_handle, uint8_t num);
 static int arctis_request_battery(hid_device* device_handle);
 static int arctis_send_inactive_time(hid_device* device_handle, uint8_t num);
 
+static int arctis_save_state(hid_device* device_handle);
+
 void arctis_init(struct device** device)
 {
     device_arctis.idVendor = VENDOR_STEELSERIES;
@@ -59,6 +61,10 @@ static int arctis_send_sidetone(hid_device* device_handle, uint8_t num)
     ret = hid_write(device_handle, buf, 31);
 
     free(buf);
+
+    if(ret >= 0) {
+        ret = arctis_save_state(device_handle);
+    }
 
     return ret;
 }
@@ -107,6 +113,30 @@ static int arctis_send_inactive_time(hid_device* device_handle, uint8_t num)
     }
 
     const unsigned char data[3] = { 0x06, 0x51, num };
+
+    memmove(buf, data, sizeof(data));
+
+    ret = hid_write(device_handle, buf, 31);
+
+    free(buf);
+
+    if(ret >= 0) {
+        ret = arctis_save_state(device_handle);
+    }
+
+    return ret;
+}
+
+int arctis_save_state(hid_device* device_handle) {
+    int ret = -1;
+
+    unsigned char* buf = calloc(31, 1);
+
+    if (!buf) {
+        return ret;
+    }
+
+    const unsigned char data[2] = { 0x06, 0x09 };
 
     memmove(buf, data, sizeof(data));
 


### PR DESCRIPTION
Add a new capability CAP_INACTIVE_TIME to set time until a device turns itself off. 
Implement this for SteelSeries Arctis which supports this. 