### PR TITLE
Add capability to read the value of the "chat-mix" slider on SteelSeries Arctis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 
 ## Supported Headsets
 
-- Corsair Void (Every version*, regardless wether Pro or Wired)
+- Corsair Void (Every version*, regardless whether Pro or Wired)
   - Sidetone, Battery (for Wireless), LED on/off, Notification Sound
 - Logitech G430
   - No support in current version (Last working on macOS in commit 41be99379f)
@@ -20,7 +20,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 - Logitech G633 / G933 / G935
   - Sidetone, Battery (for Wireless), LED on/off
 - SteelSeries Arctis (7 and Pro)
-  - Sidetone, Battery, Inactive time
+  - Sidetone, Battery, Inactive time, Chat-Mix level
 - Logitech G PRO
   - Sidetone
 
@@ -91,7 +91,7 @@ If you want to be able to call HeadsetControl from every folder type:
 ```bash
 make install
 ```
-This will copy the binary to a folder globally accessable via path.
+This will copy the binary to a folder globally accessible via path.
 
 ### Access without root
 

--- a/src/device.h
+++ b/src/device.h
@@ -15,7 +15,8 @@ enum capabilities {
     CAP_BATTERY_STATUS = 2,
     CAP_NOTIFICATION_SOUND = 4,
     CAP_LIGHTS = 8,
-    CAP_INACTIVE_TIME = 16
+    CAP_INACTIVE_TIME = 16,
+    CAP_CHATMIX_STATUS = 32
 };
 
 /** @brief Flags for battery status
@@ -122,4 +123,16 @@ struct device {
      *              -1          HIDAPI error
      */
     int (*send_inactive_time)(hid_device* hid_device, uint8_t num);
+
+    /** @brief Function pointer for retrieving the headsets chatmix level
+     *
+     *  Forwards the request to the device specific implementation
+     *
+     *  @param  device_handle   The hidapi handle. Must be the same
+     *                          device as defined here (same ids)
+     *
+     *  @returns    >= 0            chatmix level
+     *              -1              HIDAPI error
+     */
+    int (*request_chatmix)(hid_device* hid_device);
 };

--- a/src/devices/steelseries_arctis.c
+++ b/src/devices/steelseries_arctis.c
@@ -155,7 +155,8 @@ static int arctis_request_chatmix(hid_device* device_handle)
     // with "64" being in the middle
     if(game == 0 && chat == 0) {
         return 64;
-    } else if(game == 0) {
+    }
+    if(game == 0) {
         return 64 + 255 - chat;
     } else {
         return 64 + (-1)*(255 - game);

--- a/src/devices/steelseries_arctis.c
+++ b/src/devices/steelseries_arctis.c
@@ -156,9 +156,10 @@ static int arctis_request_chatmix(hid_device* device_handle)
     if(game == 0 && chat == 0) {
         return 64;
     }
+
     if(game == 0) {
         return 64 + 255 - chat;
-    } else {
-        return 64 + (-1)*(255 - game);
     }
+
+    return 64 + (-1)*(255 - game);
 }


### PR DESCRIPTION
This is a feature of the SteelSeries Arctis headset when using the bundled Windows software which allows to adjust how Game-Sound is mixed with live audio-chat via a slider on the Headset.

Reading this value allows arbitrary integrations to be built, i.e. you could use this to control play-speed in your audio player or any other integration that can be done via reading the setting of a hardware slider.

Changes:
* Added a new capability "CAP_CHATMIX_STATUS"
* Added option "-m" to read it
* Implemented the capability for the Steelseries Arctis
* Additionally fixed a few typos in the README