### PR TITLE
SteelSeries Arctis: Use LED-capability for the LED on the base-station

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 - Logitech G633 / G933 / G935
   - Sidetone, Battery (for Wireless), LED on/off
 - SteelSeries Arctis (7 and Pro)
-  - Sidetone, Battery, Inactive time, Chat-Mix level
+  - Sidetone, Battery, Inactive time, Chat-Mix level, LED on/off (allows to turn off the blinking LED on the base-station)
 - Logitech G PRO
   - Sidetone
 

--- a/src/devices/steelseries_arctis.c
+++ b/src/devices/steelseries_arctis.c
@@ -17,6 +17,7 @@ static int arctis_send_sidetone(hid_device* device_handle, uint8_t num);
 static int arctis_request_battery(hid_device* device_handle);
 static int arctis_send_inactive_time(hid_device* device_handle, uint8_t num);
 static int arctis_request_chatmix(hid_device* device_handle);
+static int arctis_switch_lights(hid_device* device_handle, uint8_t on);
 
 static int arctis_save_state(hid_device* device_handle);
 
@@ -29,11 +30,12 @@ void arctis_init(struct device** device)
 
     strncpy(device_arctis.device_name, "SteelSeries Arctis (7/Pro)", sizeof(device_arctis.device_name));
 
-    device_arctis.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS | CAP_INACTIVE_TIME | CAP_CHATMIX_STATUS;
+    device_arctis.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS | CAP_INACTIVE_TIME | CAP_CHATMIX_STATUS | CAP_LIGHTS;
     device_arctis.send_sidetone = &arctis_send_sidetone;
     device_arctis.request_battery = &arctis_request_battery;
     device_arctis.send_inactive_time = &arctis_send_inactive_time;
     device_arctis.request_chatmix = &arctis_request_chatmix;
+    device_arctis.switch_lights = &arctis_switch_lights;
 
     *device = &device_arctis;
 }
@@ -162,4 +164,16 @@ static int arctis_request_chatmix(hid_device* device_handle)
     }
 
     return 64 + (-1)*(255 - game);
+}
+
+static int arctis_switch_lights(hid_device* device_handle, uint8_t on)
+{
+    unsigned char data[8] = { 0x06, 0x55, 0x01, on ? 0x02 : 0x00 };
+    int ret = hid_write(device_handle, data, 8);
+
+    if(ret >= 0) {
+        ret = arctis_save_state(device_handle);
+    }
+
+    return ret;
 }


### PR DESCRIPTION
The SteelSeries Arctis 7 does not have LEDs as part of the headset, but there is a LED on the base-station which usually blinks when the headset is not reachable. 

When you turn off the Headset on purpose, this blinking might be irritating, so there is a protocol to turn off that LED.

This PR uses the existing "switch LED" commandline option to enable/disable this LED.