### PR TITLE
Add support for Corsair HS70 Pro.

### DIFF
--- a/src/devices/corsair_void.c
+++ b/src/devices/corsair_void.c
@@ -20,6 +20,7 @@ enum void_wireless_battery_flags {
 #define ID_CORSAIR_VOID_RGB_WIRED    0x1b1c
 #define ID_CORSAIR_VOID_ELITE_WIRELESS	0x0a55
 #define ID_CORSAIR_VOID_RGB_ELITE_WIRELESS	0x0a51
+#define ID_CORSAIR_HS70_PRO	     0x0a4f
 
 static const uint16_t PRODUCT_IDS[] = {
     ID_CORSAIR_VOID_RGB_WIRED,
@@ -32,6 +33,7 @@ static const uint16_t PRODUCT_IDS[] = {
     ID_CORSAIR_VOID_RGB_USB_2,
     ID_CORSAIR_VOID_ELITE_WIRELESS,
     ID_CORSAIR_VOID_RGB_ELITE_WIRELESS,
+    ID_CORSAIR_HS70_PRO,
 };
 
 static int void_send_sidetone(hid_device* device_handle, uint8_t num);


### PR DESCRIPTION
Since all of the controls seem to work (but no lights, since there are none) I didn't want to create a new file. Even though this model isn't from the "Void" range.

Edit: Thanks for this work btw, I'm so happy I finally have a nice Linux tool.