### PR TITLE
adding udev rule for Corsair Pro wireless headset

### DIFF
--- a/udev/70-headsets.rules
+++ b/udev/70-headsets.rules
@@ -6,6 +6,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct
 # Corsair VOID PRO
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a14", TAG+="uaccess"
 
+# Corsair VOID PRO Wireless
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a1a", TAG+="uaccess"
+
 # Corsair VOID PRO USB
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a17", TAG+="uaccess"
 


### PR DESCRIPTION
Added an additional udev rule for Corsair Pro wireless headsets. This will close issue "#96 opened on Jun 6 by simonoesterle".