### PR TITLE
Implements detection of battery not being available on VOID PRO Wireless

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -22,6 +22,7 @@ enum capabilities {
 /** @brief Flags for battery status
  */
 enum battery_status {
+    BATTERY_UNAVAILABLE = 65534,
     BATTERY_CHARGING = 65535
 };
 

--- a/src/devices/corsair_void.c
+++ b/src/devices/corsair_void.c
@@ -3,7 +3,6 @@
 
 #include <hidapi.h>
 #include <string.h>
-#include <stdio.h>
 
 static struct device device_void;
 

--- a/src/devices/corsair_void.c
+++ b/src/devices/corsair_void.c
@@ -3,6 +3,7 @@
 
 #include <hidapi.h>
 #include <string.h>
+#include <stdio.h>
 
 static struct device device_void;
 
@@ -83,7 +84,7 @@ static int void_request_battery(hid_device* device_handle)
     // Packet Description
     // Answer of battery status
     // Index    0   1   2       3       4
-    // Data     100 0   Loaded% 177     5 when loading, 1 otherwise
+    // Data     100 0   Loaded% 177     5 when loading, 0 when headset is not connected, 1 otherwise
 
     int r = 0;
 
@@ -103,7 +104,10 @@ static int void_request_battery(hid_device* device_handle)
     if (r < 0)
         return r;
 
-    if (data_read[4] == 0 || data_read[4] == 4 || data_read[4] == 5) {
+    if (data_read[4] == 0) {
+        return BATTERY_UNAVAILABLE;
+    }
+    if (data_read[4] == 4 || data_read[4] == 5) {
         return BATTERY_CHARGING;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -356,6 +356,11 @@ int main(int argc, char* argv[])
                 printf("Battery: Charging\n");
             else
                 printf("-1");
+        } else if (ret == BATTERY_UNAVAILABLE) {
+            if (!short_output)
+                printf("Battery: Unavailable\n");
+            else
+                printf("-2");
         } else {
             if (!short_output)
                 printf("Battery: %d%%\n", ret);


### PR DESCRIPTION
Relevant issue is #102.

This PR adds an additional flag to the `battery_status` enum and detects if the battery belongs to a disconnected device, making the returned battery status value useless. This has been implemented and tested for the Corsair VOID PRO Wireless headset and should be valid for any other Corsair device supported by HeadsetControl.

As I do not have any access to other devices supported by HeadsetControl, I'm unable to implement something similar for them. As it is, this PR should not negatively impact any of said other devices, but improve the output for Corsair headsets.