### PR TITLE
Adding Corsair HS70 support

### DIFF
--- a/src/devices/corsair_void.c
+++ b/src/devices/corsair_void.c
@@ -21,7 +21,9 @@ enum void_wireless_battery_flags {
 #define ID_CORSAIR_VOID_ELITE_WIRELESS     0x0a55
 #define ID_CORSAIR_VOID_RGB_ELITE_WIRELESS 0x0a51
 #define ID_CORSAIR_VOID_ELITE_USB          0x0a52
+#define ID_CORSAIR_HS70_WIRELESS           0x0a38
 #define ID_CORSAIR_HS70_PRO                0x0a4f
+
 
 static const uint16_t PRODUCT_IDS[] = {
     ID_CORSAIR_VOID_RGB_WIRED,
@@ -35,6 +37,7 @@ static const uint16_t PRODUCT_IDS[] = {
     ID_CORSAIR_VOID_ELITE_WIRELESS,
     ID_CORSAIR_VOID_RGB_ELITE_WIRELESS,
     ID_CORSAIR_VOID_ELITE_USB,
+    ID_CORSAIR_HS70_WIRELESS,
     ID_CORSAIR_HS70_PRO,
 };
 
@@ -51,7 +54,7 @@ void void_init(struct device** device)
     device_void.idUsagePage = 0xff00;
     device_void.idUsage = 0x1;
 
-    strncpy(device_void.device_name, "Corsair Void (Pro)", sizeof(device_void.device_name));
+    strncpy(device_void.device_name, "Corsair Headset Device", sizeof(device_void.device_name));
 
     device_void.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS | CAP_NOTIFICATION_SOUND | CAP_LIGHTS;
     device_void.send_sidetone = &void_send_sidetone;

--- a/udev/70-headsets.rules
+++ b/udev/70-headsets.rules
@@ -24,6 +24,12 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct
 # Corsair VOID
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1b27", TAG+="uaccess"
 
+# Corsair HS70 Wireless
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a38", TAG+="uaccess"
+
+# Corsair HS70 Pro
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0a4f", TAG+="uaccess"
+
 # Logitech G430
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0a4d", TAG+="uaccess"
 


### PR DESCRIPTION
Hi, in this PR I'm adding support to [Corsair HS70](https://www.corsair.com/us/en/Categories/Products/Gaming-Headsets/Wireless-Headsets/HS70-Wireless-Gaming-Headset/p/CA-9011179-NA) and improving the support to [HS70 PRO](https://www.corsair.com/us/en/Categories/Products/Gaming-Headsets/Wireless-Headsets/HS70-PRO-WIRELESS-Gaming-Headset/p/CA-9011211-NA). 
Basically, I insert a new device ID in `src/devices/corsair_void.c` (HS70) and updated the `udev/70-headsets.rules` with the HS70 and HS70 Pro data, thus allowing the `headsetcontrol` command works without `sudo` to its devices =)