### PR TITLE
Add support for the SteelSeries Arctis 1 Wireless for XBox

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -51,7 +51,7 @@ struct device {
     uint16_t idUsage;
 
     /// Name of device, used as information for the user
-    char device_name[32];
+    char device_name[64];
 
     /// Bitmask of currently supported features the software can currently handle
     int capabilities;

--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -7,11 +7,12 @@
 #include "devices/logitech_g930.h"
 #include "devices/logitech_gpro.h"
 #include "devices/steelseries_arctis_1.h"
+#include "devices/steelseries_arctis_1_xbox.h"
 #include "devices/steelseries_arctis_7.h"
 
 #include <string.h>
 
-#define NUMDEVICES 8
+#define NUMDEVICES 9
 // array of pointers to device
 static struct device*(devicelist[NUMDEVICES]);
 
@@ -25,6 +26,7 @@ void init_devices()
     arctis_1_init(&devicelist[5]);
     arctis_7_init(&devicelist[6]);
     gpro_init(&devicelist[7]);
+    arctis_1_xbox_init(&devicelist[8]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g533.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_1.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_1.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_1_xbox.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_1_xbox.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.h
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_g933_935.c

--- a/src/devices/steelseries_arctis_1.c
+++ b/src/devices/steelseries_arctis_1.c
@@ -26,7 +26,7 @@ void arctis_1_init(struct device** device)
     device_arctis.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
     device_arctis.idInterface = 0x03;
 
-    strncpy(device_arctis.device_name, "SteelSeries Arctis (1)", sizeof(device_arctis.device_name));
+    strncpy(device_arctis.device_name, "SteelSeries Arctis (1) Wireless", sizeof(device_arctis.device_name));
 
     device_arctis.capabilities = CAP_SIDETONE | CAP_INACTIVE_TIME;
     device_arctis.send_sidetone = &arctis_1_send_sidetone;

--- a/src/devices/steelseries_arctis_1_xbox.c
+++ b/src/devices/steelseries_arctis_1_xbox.c
@@ -1,0 +1,126 @@
+#include "../device.h"
+#include "../utility.h"
+
+#include <hidapi.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <stdio.h>
+
+static struct device device_arctis;
+
+#define ID_ARCTIS_1_XBOX 0x12b6
+
+static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_1_XBOX };
+
+static int arctis_1_xbox_send_sidetone(hid_device* device_handle, uint8_t num);
+static int arctis_1_xbox_request_battery(hid_device* device_handle);
+static int arctis_1_xbox_send_inactive_time(hid_device* device_handle, uint8_t num);
+
+static int arctis_1_xbox_save_state(hid_device* device_handle);
+
+void arctis_1_xbox_init(struct device** device)
+{
+    device_arctis.idVendor = VENDOR_STEELSERIES;
+    device_arctis.idProductsSupported = PRODUCT_IDS;
+    device_arctis.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_arctis.idInterface = 0x03;
+
+    strncpy(device_arctis.device_name, "SteelSeries Arctis (1) Wireless For XBox", sizeof(device_arctis.device_name));
+
+    device_arctis.capabilities = CAP_SIDETONE | CAP_INACTIVE_TIME | CAP_BATTERY_STATUS;
+    device_arctis.send_sidetone = &arctis_1_xbox_send_sidetone;
+    device_arctis.request_battery = &arctis_1_xbox_request_battery;
+    device_arctis.send_inactive_time = &arctis_1_xbox_send_inactive_time;
+
+    *device = &device_arctis;
+}
+
+static int arctis_1_xbox_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    int ret = -1;
+
+    // the range of the Arctis 1 seems to be from 0 to 0x12 (18)
+    num = map(num, 0, 128, 0x00, 0x12);
+
+    unsigned char* buf = calloc(31, 1);
+
+    if (!buf) {
+        return ret;
+    }
+
+    const unsigned char data_on[5] = { 0x06, 0x35, 0x01, 0x00, num };
+    const unsigned char data_off[2] = { 0x06, 0x35 };
+
+    if (num) {
+        memmove(buf, data_on, sizeof(data_on));
+    } else {
+        memmove(buf, data_off, sizeof(data_off));
+    }
+
+    ret = hid_write(device_handle, buf, 31);
+
+    free(buf);
+
+    if (ret >= 0) {
+        ret = arctis_1_xbox_save_state(device_handle);
+    }
+
+    return ret;
+}
+
+static int arctis_1_xbox_request_battery(hid_device* device_handle)
+{
+
+    int r = 0;
+
+    // request battery status
+    unsigned char data_request[2] = { 0x06, 0x12 };
+
+    r = hid_write(device_handle, data_request, 2);
+
+    if (r < 0)
+        return r;
+
+    // read battery status
+    unsigned char data_read[8];
+
+    r = hid_read(device_handle, data_read, 8);
+
+    if (r < 0)
+        return r;
+
+    if (data_read[2] == 0x01)
+      return BATTERY_UNAVAILABLE;
+
+    int bat = data_read[3];
+
+    if (bat > 100)
+        return 100;
+
+    return bat;
+}
+
+static int arctis_1_xbox_send_inactive_time(hid_device* device_handle, uint8_t num)
+{
+    // as the value is in minutes, mapping to a different range does not make too much sense here
+    // the range of the Arctis 7 seems to be from 0 to 0x5A (90)
+    // num = map(num, 0, 128, 0x00, 0x5A);
+
+    uint8_t data[31] = { 0x06, 0x51, num };
+
+    int ret = hid_write(device_handle, data, 31);
+
+    if (ret >= 0) {
+        ret = arctis_1_xbox_save_state(device_handle);
+    }
+
+    return ret;
+}
+
+int arctis_1_xbox_save_state(hid_device* device_handle)
+{
+    uint8_t data[31] = { 0x06, 0x09 };
+
+    return hid_write(device_handle, data, 31);
+}

--- a/src/devices/steelseries_arctis_1_xbox.h
+++ b/src/devices/steelseries_arctis_1_xbox.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void arctis_1_xbox_init(struct device** device);


### PR DESCRIPTION
Battery level _seems_ to be correct. I couldn't/didn't test the sidetone level (I have no idea what that is), and the timeout didn't work either, but I wonder how it detects usage (I had the mic disabled on the headset, but PulseAudio running).