### PR TITLE
Added support for SteelSeries Arctis 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
   - Sidetone, Battery (for Wireless), LED on/off
 - SteelSeries Arctis (7 and Pro)
   - Sidetone, Battery, Inactive time, Chat-Mix level, LED on/off (allows to turn off the blinking LED on the base-station)
+- SteelSeries Arctis 9
+  - Sidetone, Battery, Inactive time, Chat-Mix level
 - Logitech G PRO
   - Sidetone
 

--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -9,10 +9,11 @@
 #include "devices/steelseries_arctis_1.h"
 #include "devices/steelseries_arctis_1_xbox.h"
 #include "devices/steelseries_arctis_7.h"
+#include "devices/steelseries_arctis_9.h"
 
 #include <string.h>
 
-#define NUMDEVICES 9
+#define NUMDEVICES 10
 // array of pointers to device
 static struct device*(devicelist[NUMDEVICES]);
 
@@ -25,8 +26,9 @@ void init_devices()
     g933_935_init(&devicelist[4]);
     arctis_1_init(&devicelist[5]);
     arctis_7_init(&devicelist[6]);
-    gpro_init(&devicelist[7]);
-    arctis_1_xbox_init(&devicelist[8]);
+    arctis_9_init(&devicelist[7]);
+    gpro_init(&devicelist[8]);
+    arctis_1_xbox_init(&devicelist[9]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_1_xbox.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.h
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_g933_935.c
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_g933_935.h
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_gpro.c

--- a/src/devices/steelseries_arctis_9.c
+++ b/src/devices/steelseries_arctis_9.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <math.h>
 #include <stdio.h>
 
 static struct device device_arctis;
@@ -12,7 +13,7 @@ static struct device device_arctis;
 #define ID_ARCTIS_9        0x12c2
 
 #define BATTERY_MAX 0x9A
-#define BATTERY_MIN 0x68
+#define BATTERY_MIN 0x64
 
 static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_9 };
 
@@ -45,6 +46,9 @@ void arctis_9_init(struct device** device)
 static int arctis_9_send_sidetone(hid_device* device_handle, uint8_t num)
 {
     int ret = -1;
+
+    // transform the log scale sidetone into a more intuitive linear scale
+    num = map(log2(num) * 100, 0, 700, 0, 128);
 
     // the range of the Arctis 9 seems to be from 0xc0 (192, also off) to 0xfd (253)
     // and scales exponential

--- a/src/devices/steelseries_arctis_9.c
+++ b/src/devices/steelseries_arctis_9.c
@@ -11,6 +11,9 @@ static struct device device_arctis;
 
 #define ID_ARCTIS_9        0x12c2
 
+#define BATTERY_MAX 0x9A
+#define BATTERY_MIN 0x00
+
 static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_9 };
 
 static int arctis_9_send_sidetone(hid_device* device_handle, uint8_t num);
@@ -112,10 +115,10 @@ static int arctis_9_request_battery(hid_device* device_handle)
     printf("%02X\n", bat);
     printf("%d\n", bat);
 
-    if (bat > 255)
+    if (bat > BATTERY_MAX)
         return 100;
 
-    return 100.0 / 255 * bat;
+    return map(bat, BATTERY_MIN, BATTERY_MAX, 0, 100);
 }
 
 static int arctis_9_send_inactive_time(hid_device* device_handle, uint8_t num)

--- a/src/devices/steelseries_arctis_9.c
+++ b/src/devices/steelseries_arctis_9.c
@@ -48,7 +48,7 @@ static int arctis_9_send_sidetone(hid_device* device_handle, uint8_t num)
     int ret = -1;
 
     // transform the log scale sidetone into a more intuitive linear scale
-    num = map(log2(num) * 100, 0, 700, 0, 128);
+    num = map((int)log2(num) * 100, 0, 700, 0, 128);
 
     // the range of the Arctis 9 seems to be from 0xc0 (192, also off) to 0xfd (253)
     // and scales exponential

--- a/src/devices/steelseries_arctis_9.c
+++ b/src/devices/steelseries_arctis_9.c
@@ -1,0 +1,141 @@
+#include "../device.h"
+#include "../utility.h"
+
+#include <hidapi.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <stdio.h>
+
+static struct device device_arctis;
+
+#define ID_ARCTIS_9        0x12c2
+
+static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_9 };
+
+static int arctis_9_send_sidetone(hid_device* device_handle, uint8_t num);
+static int arctis_9_request_battery(hid_device* device_handle);
+static int arctis_9_send_inactive_time(hid_device* device_handle, uint8_t num);
+
+static int arctis_9_save_state(hid_device* device_handle);
+
+void arctis_9_init(struct device** device)
+{
+    device_arctis.idVendor = VENDOR_STEELSERIES;
+    device_arctis.idProductsSupported = PRODUCT_IDS;
+    device_arctis.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_arctis.idInterface = 0x00;
+
+    strncpy(device_arctis.device_name, "SteelSeries Arctis 9", sizeof(device_arctis.device_name));
+
+    device_arctis.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS | CAP_INACTIVE_TIME;
+    device_arctis.send_sidetone = &arctis_9_send_sidetone;
+    device_arctis.request_battery = &arctis_9_request_battery;
+    device_arctis.send_inactive_time = &arctis_9_send_inactive_time;
+
+    *device = &device_arctis;
+}
+
+static int arctis_9_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    int ret = -1;
+
+    // the range of the Arctis 9 seems to be from 0xc0 (192, also off) to 0xfd (253)
+    // and scales exponential
+    num = map(num, 0, 128, 0xc0, 0xfd);
+
+    unsigned char* buf = calloc(31, 1);
+
+    if (!buf) {
+        return ret;
+    }
+
+    const unsigned char data_on[5] = { 0x06, 0x00, num };
+    const unsigned char data_off[3] = { 0x06, 0x00, 0xc0 };
+
+    if (num) {
+        memmove(buf, data_on, sizeof(data_on));
+    } else {
+        memmove(buf, data_off, sizeof(data_off));
+    }
+
+    ret = hid_write(device_handle, buf, 31);
+
+    free(buf);
+
+    if (ret >= 0) {
+        ret = arctis_9_save_state(device_handle);
+    }
+
+    return ret;
+}
+
+static int arctis_9_request_battery(hid_device* device_handle)
+{
+    int r = 0;
+
+    unsigned char* buf = calloc(31, 1);
+
+    if (!buf) {
+        return r;
+    }
+
+    // request battery status
+    unsigned char data_request[2] = { 0x20, 0x00 };
+
+    memmove(buf, data_request, sizeof(data_request));
+
+    r = hid_write(device_handle, buf, 31);
+
+    if (r < 0)
+        return r;
+
+    // read battery status
+    unsigned char data_read[64];
+
+    r = hid_read(device_handle, data_read, 64);
+
+    if (r < 0)
+        return r;
+ 
+
+    int i;
+    for (i = 0; i < 64; i++)
+    {
+        if (i > 0) printf(":");
+        printf("%02X", data_read[i]);
+    }
+    printf("\n");
+
+    int bat = data_read[3];
+
+    printf("%02X\n", bat);
+    printf("%d\n", bat);
+
+    if (bat > 255)
+        return 100;
+
+    return 100.0 / 255 * bat;
+}
+
+static int arctis_9_send_inactive_time(hid_device* device_handle, uint8_t num)
+{
+    // the value for the Arctis 9 needs to be in seconds
+    uint32_t time = num * 60;
+    uint8_t data[31] = { 0x04, 0x00, (uint8_t)(time >> 8), (uint8_t)(time) };
+
+    int ret = hid_write(device_handle, data, 31);
+
+    if (ret >= 0) {
+        ret = arctis_9_save_state(device_handle);
+    }
+
+    return ret;
+}
+
+int arctis_9_save_state(hid_device* device_handle)
+{
+    uint8_t data[31] = { 0x90, 0x00 };
+
+    return hid_write(device_handle, data, 31);
+}

--- a/src/devices/steelseries_arctis_9.h
+++ b/src/devices/steelseries_arctis_9.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void arctis_9_init(struct device** device);

--- a/udev/70-headsets.rules
+++ b/udev/70-headsets.rules
@@ -72,4 +72,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct
 # SteelSeries ARCTIS PRO (2019)
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1252", TAG+="uaccess"
 
+# SteelSeries ARCTIS 9
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="12c2", TAG+="uaccess"
+
 LABEL="headset_end"


### PR DESCRIPTION
I added support for the new SteelSeries Arctis 9.

I'm not entirely sure what method they are using to report the battery level. So I'm just using the [reported values](https://github.com/rhwilrForks/HeadsetControl/blob/master/src/devices/steelseries_arctis_9.c#L15-L16) and mapping it to a percentage. Also, the sidetone setting is some exponential curve, so a did my best to map it to a scale that feels linear.

Hope you find this useful, as others seem to be looking for this as well (#115).
If you require any changes, feel free to let me know.