### PR TITLE
Added overlay instructions for Gentoo ebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ RHEL and CentOS also require the epel-repository: `yum install epel-release`. Pl
 
 #### Gentoo
 
-A [ebuild](https://github.com/Sapd/HeadsetControl/wiki/Gentoo-ebuild) is available in project wiki.
+1. Enable [nitratesky](https://github.com/VTimofeenko/nitratesky) overlay:
+
+    `eselect repository enable nitratesky`
+2. Install:
+
+    `emerge -a app-misc/headsetcontrol`
 
 #### Mac OS X
 


### PR DESCRIPTION
My overlay (where the ebuild from wiki was duplicated) has been added to the list of Gentoo overlays, so a user can now just enable it and install the package.