### PR TITLE
Keep recognition separated and device handling as one

### DIFF
--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -3,8 +3,12 @@
 #include "devices/corsair_void.h"
 #include "devices/logitech_g430.h"
 #include "devices/logitech_g533.h"
-#include "devices/logitech_g633_g933_935.h"
+#include "devices/logitech_g633.h"
+#include "devices/logitech_g635.h"
+#include "devices/logitech_g733.h"
 #include "devices/logitech_g930.h"
+#include "devices/logitech_g933.h"
+#include "devices/logitech_g935.h"
 #include "devices/logitech_gpro.h"
 #include "devices/steelseries_arctis_1.h"
 #include "devices/steelseries_arctis_1_xbox.h"
@@ -13,7 +17,7 @@
 
 #include <string.h>
 
-#define NUMDEVICES 10
+#define NUMDEVICES 14
 
 // array of pointers to device
 static struct device*(devicelist[NUMDEVICES]);
@@ -23,13 +27,17 @@ void init_devices()
     void_init(&devicelist[0]);
     g430_init(&devicelist[1]);
     g533_init(&devicelist[2]);
-    g930_init(&devicelist[3]);
-    g933_935_init(&devicelist[4]);
-    arctis_1_init(&devicelist[5]);
-    arctis_7_init(&devicelist[6]);
-    arctis_9_init(&devicelist[7]);
-    gpro_init(&devicelist[8]);
-    arctis_1_xbox_init(&devicelist[9]);
+    g633_init(&devicelist[3]);
+    g635_init(&devicelist[4]);
+    g733_init(&devicelist[5]);
+    g930_init(&devicelist[6]);
+    g933_init(&devicelist[7]);
+    g935_init(&devicelist[8]);
+    arctis_1_init(&devicelist[9]);
+    arctis_7_init(&devicelist[10]);
+    arctis_9_init(&devicelist[11]);
+    gpro_init(&devicelist[12]);
+    arctis_1_xbox_init(&devicelist[13]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -15,8 +15,18 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_g933_935.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_g933_935.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_635_733_933_935.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_635_733_933_935.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g635.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g635.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g733.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g733.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g933.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g933.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g935.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g935.h
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_gpro.c
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_gpro.h
     PARENT_SCOPE)

--- a/src/devices/logitech_g633.c
+++ b/src/devices/logitech_g633.c
@@ -1,0 +1,38 @@
+#include "../device.h"
+#include "logitech_g633_635_733_933_935.h"
+#include <hidapi.h>
+
+static struct device device_g633;
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633 };
+
+static int g633_send_sidetone(hid_device* device_handle, uint8_t num);
+static int g633_request_battery(hid_device* device_handle);
+static int g633_lights(hid_device* device_handle, uint8_t on);
+
+void g633_init(struct device** device)
+{
+    g633_635_733_933_935_init(&device_g633, "Logitech G633 Gaming Headset");
+    device_g633.idProductsSupported = PRODUCT_IDS;
+    device_g633.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_g633.send_sidetone = &g633_send_sidetone;
+    device_g633.request_battery = &g633_request_battery;
+    device_g633.switch_lights = &g633_lights;
+
+    *device = &device_g633;
+}
+
+static int g633_request_battery(hid_device* device_handle)
+{
+    return g633_635_733_933_935_request_battery(device_handle);
+}
+
+static int g633_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    return g633_635_733_933_935_send_sidetone(device_handle, num);
+}
+
+static int g633_lights(hid_device* device_handle, uint8_t on)
+{
+    return g633_635_733_933_935_lights(device_handle, on);
+}

--- a/src/devices/logitech_g633.h
+++ b/src/devices/logitech_g633.h
@@ -1,0 +1,1 @@
+void g633_init(struct device** device);

--- a/src/devices/logitech_g633_635_733_933_935.c
+++ b/src/devices/logitech_g633_635_733_933_935.c
@@ -7,38 +7,24 @@
 #include <string.h>
 #include <unistd.h>
 
-static struct device device_g933_935;
+static struct device device_g633_635_733_933_935;
 
-#define ID_LOGITECH_G633 0x0a5c
-#define ID_LOGITECH_G635 0x0a89
-#define ID_LOGITECH_G933 0x0a5b
-#define ID_LOGITECH_G935 0x0a87
-#define ID_LOGITECH_G733 0x0ab5
+int g633_635_733_933_935_send_sidetone(hid_device* device_handle, uint8_t num);
+int g633_635_733_933_935_request_battery(hid_device* device_handle);
+int g633_635_733_933_935_lights(hid_device* device_handle, uint8_t on);
 
-static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733 };
-
-static int g933_935_send_sidetone(hid_device* device_handle, uint8_t num);
-static int g933_935_request_battery(hid_device* device_handle);
-static int g933_935_lights(hid_device* device_handle, uint8_t on);
-
-void g933_935_init(struct device** device)
+void g633_635_733_933_935_init(struct device* device, char* name)
 {
-    device_g933_935.idVendor = VENDOR_LOGITECH;
-    device_g933_935.idProductsSupported = PRODUCT_IDS;
-    device_g933_935.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
-    device_g933_935.idUsagePage = 0xff43;
-    device_g933_935.idUsage = 0x0202;
-    strncpy(device_g933_935.device_name, "Logitech G633/G635/G933/G935", sizeof(device_g933_935.device_name));
+    device_g633_635_733_933_935.idVendor = VENDOR_LOGITECH;
+    device_g633_635_733_933_935.idUsagePage = 0xff43;
+    device_g633_635_733_933_935.idUsage = 0x0202;
+    strncpy(device_g633_635_733_933_935.device_name, name, sizeof(device_g633_635_733_933_935.device_name));
+    device_g633_635_733_933_935.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS | CAP_LIGHTS;
 
-    device_g933_935.capabilities = CAP_SIDETONE | CAP_BATTERY_STATUS | CAP_LIGHTS;
-    device_g933_935.send_sidetone = &g933_935_send_sidetone;
-    device_g933_935.request_battery = &g933_935_request_battery;
-    device_g933_935.switch_lights = &g933_935_lights;
-
-    *device = &device_g933_935;
+    *device = device_g633_635_733_933_935;
 }
 
-static float estimate_battery_level(uint16_t voltage)
+float estimate_battery_level(uint16_t voltage)
 {
     if (voltage <= 3525)
         return (float)((0.03 * voltage) - 101);
@@ -48,7 +34,7 @@ static float estimate_battery_level(uint16_t voltage)
     return (float)(0.0000000037268473047 * pow(voltage, 4) - 0.00005605626214573775 * pow(voltage, 3) + 0.3156051902814949 * pow(voltage, 2) - 788.0937250298629 * voltage + 736315.3077118985);
 }
 
-static int g933_935_request_battery(hid_device* device_handle)
+int g633_635_733_933_935_request_battery(hid_device* device_handle)
 {
     /*
         CREDIT GOES TO https://github.com/ashkitten/ for the project
@@ -88,7 +74,7 @@ static int g933_935_request_battery(hid_device* device_handle)
     return (int)(roundf(estimate_battery_level(voltage)));
 }
 
-static int g933_935_send_sidetone(hid_device* device_handle, uint8_t num)
+int g633_635_733_933_935_send_sidetone(hid_device* device_handle, uint8_t num)
 {
     if (num > 0x64)
         num = 0x64;
@@ -102,7 +88,7 @@ static int g933_935_send_sidetone(hid_device* device_handle, uint8_t num)
     return hid_write(device_handle, data_send, sizeof(data_send) / sizeof(data_send[0]));
 }
 
-static int g933_935_lights(hid_device* device_handle, uint8_t on)
+int g633_635_733_933_935_lights(hid_device* device_handle, uint8_t on)
 {
     // on, breathing  11 ff 04 3c 01 (0 for logo) 02 00 b6 ff 0f a0 00 64 00 00 00
     // off            11 ff 04 3c 01 (0 for logo) 00

--- a/src/devices/logitech_g633_635_733_933_935.h
+++ b/src/devices/logitech_g633_635_733_933_935.h
@@ -1,0 +1,10 @@
+#define ID_LOGITECH_G633 0x0a5c
+#define ID_LOGITECH_G635 0x0a89
+#define ID_LOGITECH_G933 0x0a5b
+#define ID_LOGITECH_G935 0x0a87
+#define ID_LOGITECH_G733 0x0ab5
+
+extern void g633_635_733_933_935_init(struct device* device, char* name);
+extern int g633_635_733_933_935_request_battery(hid_device* device_handle);
+extern int g633_635_733_933_935_send_sidetone(hid_device* device_handle, uint8_t num);
+extern int g633_635_733_933_935_lights(hid_device* device_handle, uint8_t on);

--- a/src/devices/logitech_g633_g933_935.h
+++ b/src/devices/logitech_g633_g933_935.h
@@ -1,1 +1,0 @@
-void g933_935_init(struct device** device);

--- a/src/devices/logitech_g635.c
+++ b/src/devices/logitech_g635.c
@@ -1,0 +1,38 @@
+#include "../device.h"
+#include "logitech_g633_635_733_933_935.h"
+#include <hidapi.h>
+
+static struct device device_g635;
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G635 };
+
+static int g635_send_sidetone(hid_device* device_handle, uint8_t num);
+static int g635_request_battery(hid_device* device_handle);
+static int g635_lights(hid_device* device_handle, uint8_t on);
+
+void g635_init(struct device** device)
+{
+    g633_635_733_933_935_init(&device_g635, "Logitech G635 Gaming Headset");
+    device_g635.idProductsSupported = PRODUCT_IDS;
+    device_g635.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_g635.send_sidetone = &g635_send_sidetone;
+    device_g635.request_battery = &g635_request_battery;
+    device_g635.switch_lights = &g635_lights;
+
+    *device = &device_g635;
+}
+
+static int g635_request_battery(hid_device* device_handle)
+{
+    return g633_635_733_933_935_request_battery(device_handle);
+}
+
+static int g635_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    return g633_635_733_933_935_send_sidetone(device_handle, num);
+}
+
+static int g635_lights(hid_device* device_handle, uint8_t on)
+{
+    return g633_635_733_933_935_lights(device_handle, on);
+}

--- a/src/devices/logitech_g635.h
+++ b/src/devices/logitech_g635.h
@@ -1,0 +1,1 @@
+void g635_init(struct device** device);

--- a/src/devices/logitech_g733.c
+++ b/src/devices/logitech_g733.c
@@ -1,0 +1,38 @@
+#include "../device.h"
+#include "logitech_g633_635_733_933_935.h"
+#include <hidapi.h>
+
+static struct device device_g733;
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G733 };
+
+static int g733_send_sidetone(hid_device* device_handle, uint8_t num);
+static int g733_request_battery(hid_device* device_handle);
+static int g733_lights(hid_device* device_handle, uint8_t on);
+
+void g733_init(struct device** device)
+{
+    g633_635_733_933_935_init(&device_g733, "Logitech G733 Gaming Headset");
+    device_g733.idProductsSupported = PRODUCT_IDS;
+    device_g733.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_g733.send_sidetone = &g733_send_sidetone;
+    device_g733.request_battery = &g733_request_battery;
+    device_g733.switch_lights = &g733_lights;
+
+    *device = &device_g733;
+}
+
+static int g733_request_battery(hid_device* device_handle)
+{
+    return g633_635_733_933_935_request_battery(device_handle);
+}
+
+static int g733_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    return g633_635_733_933_935_send_sidetone(device_handle, num);
+}
+
+static int g733_lights(hid_device* device_handle, uint8_t on)
+{
+    return g633_635_733_933_935_lights(device_handle, on);
+}

--- a/src/devices/logitech_g733.h
+++ b/src/devices/logitech_g733.h
@@ -1,0 +1,1 @@
+void g733_init(struct device** device);

--- a/src/devices/logitech_g933.c
+++ b/src/devices/logitech_g933.c
@@ -1,0 +1,38 @@
+#include "../device.h"
+#include "logitech_g633_635_733_933_935.h"
+#include <hidapi.h>
+
+static struct device device_g933;
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G933 };
+
+static int g933_send_sidetone(hid_device* device_handle, uint8_t num);
+static int g933_request_battery(hid_device* device_handle);
+static int g933_lights(hid_device* device_handle, uint8_t on);
+
+void g933_init(struct device** device)
+{
+    g633_635_733_933_935_init(&device_g933, "Logitech G933 Gaming Headset");
+    device_g933.idProductsSupported = PRODUCT_IDS;
+    device_g933.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_g933.send_sidetone = &g933_send_sidetone;
+    device_g933.request_battery = &g933_request_battery;
+    device_g933.switch_lights = &g933_lights;
+
+    *device = &device_g933;
+}
+
+static int g933_request_battery(hid_device* device_handle)
+{
+    return g633_635_733_933_935_request_battery(device_handle);
+}
+
+static int g933_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    return g633_635_733_933_935_send_sidetone(device_handle, num);
+}
+
+static int g933_lights(hid_device* device_handle, uint8_t on)
+{
+    return g633_635_733_933_935_lights(device_handle, on);
+}

--- a/src/devices/logitech_g933.h
+++ b/src/devices/logitech_g933.h
@@ -1,0 +1,1 @@
+void g933_init(struct device** device);

--- a/src/devices/logitech_g935.c
+++ b/src/devices/logitech_g935.c
@@ -1,0 +1,38 @@
+#include "../device.h"
+#include "logitech_g633_635_733_933_935.h"
+#include <hidapi.h>
+
+static struct device device_g935;
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G935 };
+
+static int g935_send_sidetone(hid_device* device_handle, uint8_t num);
+static int g935_request_battery(hid_device* device_handle);
+static int g935_lights(hid_device* device_handle, uint8_t on);
+
+void g935_init(struct device** device)
+{
+    g633_635_733_933_935_init(&device_g935, "Logitech G935 Gaming Headset");
+    device_g935.idProductsSupported = PRODUCT_IDS;
+    device_g935.numIdProducts = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_g935.send_sidetone = &g935_send_sidetone;
+    device_g935.request_battery = &g935_request_battery;
+    device_g935.switch_lights = &g935_lights;
+
+    *device = &device_g935;
+}
+
+static int g935_request_battery(hid_device* device_handle)
+{
+    return g633_635_733_933_935_request_battery(device_handle);
+}
+
+static int g935_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    return g633_635_733_933_935_send_sidetone(device_handle, num);
+}
+
+static int g935_lights(hid_device* device_handle, uint8_t on)
+{
+    return g633_635_733_933_935_lights(device_handle, on);
+}

--- a/src/devices/logitech_g935.h
+++ b/src/devices/logitech_g935.h
@@ -1,0 +1,1 @@
+void g935_init(struct device** device);


### PR DESCRIPTION
Fix devices handling to keep requests as one for all matching devices:

- G633
- G635
- G733
- G933
- G935

But keeping recognition separately