### PR TITLE
Add sidetone support for Logitech Zone Wired headset

### DIFF
--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -6,6 +6,7 @@
 #include "devices/logitech_g633_g933_935.h"
 #include "devices/logitech_g930.h"
 #include "devices/logitech_gpro.h"
+#include "devices/logitech_zone_wired.h"
 #include "devices/steelseries_arctis_1.h"
 #include "devices/steelseries_arctis_1_xbox.h"
 #include "devices/steelseries_arctis_7.h"
@@ -13,7 +14,7 @@
 
 #include <string.h>
 
-#define NUMDEVICES 10
+#define NUMDEVICES 11
 
 // array of pointers to device
 static struct device*(devicelist[NUMDEVICES]);
@@ -30,6 +31,7 @@ void init_devices()
     arctis_9_init(&devicelist[7]);
     gpro_init(&devicelist[8]);
     arctis_1_xbox_init(&devicelist[9]);
+    zone_wired_init(&devicelist[10]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -19,4 +19,6 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_g633_g933_935.h
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_gpro.c
     ${CMAKE_CURRENT_SOURCE_DIR}/logitech_gpro.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_zone_wired.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/logitech_zone_wired.h
     PARENT_SCOPE)

--- a/src/devices/logitech_zone_wired.c
+++ b/src/devices/logitech_zone_wired.c
@@ -1,0 +1,42 @@
+#include "../device.h"
+#include "../utility.h"
+#include "logitech.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <hidapi.h>
+#include <string.h>
+
+#define MSG_SIZE    20
+
+static struct device device_zone_wired;
+
+static const uint16_t PRODUCT_ID = 0x0aad;
+
+static int zone_wired_send_sidetone(hid_device* device_handle, uint8_t num);
+
+void zone_wired_init(struct device** device)
+{
+    device_zone_wired.idVendor = VENDOR_LOGITECH;
+    device_zone_wired.idProductsSupported = &PRODUCT_ID;
+    device_zone_wired.numIdProducts = 1;
+    device_zone_wired.idUsage = 0x0;
+
+    strncpy(device_zone_wired.device_name, "Logitech Zone Wired", sizeof(device_zone_wired.device_name));
+
+    device_zone_wired.capabilities = CAP_SIDETONE;
+    device_zone_wired.send_sidetone = &zone_wired_send_sidetone;
+
+    *device = &device_zone_wired;
+}
+
+static int zone_wired_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    // The sidetone volume of the Zone Wired is configured in steps of 10%, with 0x00 = 0% and 0x0A = 100%
+    uint8_t raw_volume = map(num, 0, 128, 0, 10);
+    uint8_t data[MSG_SIZE] = { 0x22, 0xF1, 0x04, 0x00, 0x04, 0x3d, raw_volume, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+    return hid_send_feature_report(device_handle, data, MSG_SIZE);
+}

--- a/src/devices/logitech_zone_wired.h
+++ b/src/devices/logitech_zone_wired.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void zone_wired_init(struct device** device);

--- a/udev/70-headsets.rules
+++ b/udev/70-headsets.rules
@@ -60,6 +60,9 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct
 # logitech G PRO
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0aa7", TAG+="uaccess"
 
+# logitech Zone Wired
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="0aad", TAG+="uaccess"
+
 # SteelSeries ARCTIS 1
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="12b3", TAG+="uaccess"
 


### PR DESCRIPTION
This PR adds support for the Logitech Zone Wired headset and configuring its sidetone volume.