### PR TITLE
Add two additional capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
   - Sidetone, Battery, Inactive time, Chat-Mix level
 - Logitech G PRO
   - Sidetone
+- Logitech Zone Wired
+  - Sidetone, Voice prompts, Rotate to mute
 
 For non-supported headsets on Linux: There is a chance that you can set the sidetone via AlsaMixer
 

--- a/src/device.h
+++ b/src/device.h
@@ -16,7 +16,9 @@ enum capabilities {
     CAP_NOTIFICATION_SOUND = 4,
     CAP_LIGHTS = 8,
     CAP_INACTIVE_TIME = 16,
-    CAP_CHATMIX_STATUS = 32
+    CAP_CHATMIX_STATUS = 32,
+    CAP_VOICE_PROMPTS = 64,
+    CAP_ROTATE_TO_MUTE = 128,
 };
 
 /** @brief Flags for battery status
@@ -136,4 +138,32 @@ struct device {
      *              -1              HIDAPI error
      */
     int (*request_chatmix)(hid_device* hid_device);
+
+    /** @brief Function pointer for enabling or disabling voice
+     *  prompts on the headset
+     *
+     *  Forwards the request to the device specific implementation
+     *
+     *  @param  device_handle   The hidapi handle. Must be the same
+     *                          device as defined here (same ids)
+     *  @param  on              1 if it should be turned on; 0 otherwise
+     *
+     *  @returns    > 0         success
+     *              -1          HIDAPI error
+     */
+    int (*switch_voice_prompts)(hid_device* hid_device, uint8_t on);
+
+    /** @brief Function pointer for enabling or disabling auto-muting
+     *  when rotating the headset microphone
+     *
+     *  Forwards the request to the device specific implementation
+     *
+     *  @param  device_handle   The hidapi handle. Must be the same
+     *                          device as defined here (same ids)
+     *  @param  on              1 if it should be turned on; 0 otherwise
+     *
+     *  @returns    > 0         success
+     *              -1          HIDAPI error
+     */
+    int (*switch_rotate_to_mute)(hid_device* hid_device, uint8_t on);
 };

--- a/src/devices/logitech_zone_wired.c
+++ b/src/devices/logitech_zone_wired.c
@@ -16,6 +16,8 @@ static struct device device_zone_wired;
 static const uint16_t PRODUCT_ID = 0x0aad;
 
 static int zone_wired_send_sidetone(hid_device* device_handle, uint8_t num);
+static int zone_wired_switch_voice_prompts(hid_device* device_handle, uint8_t on);
+static int zone_wired_switch_rotate_to_mute(hid_device* device_handle, uint8_t on);
 
 void zone_wired_init(struct device** device)
 {
@@ -26,8 +28,10 @@ void zone_wired_init(struct device** device)
 
     strncpy(device_zone_wired.device_name, "Logitech Zone Wired", sizeof(device_zone_wired.device_name));
 
-    device_zone_wired.capabilities = CAP_SIDETONE;
+    device_zone_wired.capabilities = CAP_SIDETONE | CAP_VOICE_PROMPTS | CAP_ROTATE_TO_MUTE;
     device_zone_wired.send_sidetone = &zone_wired_send_sidetone;
+    device_zone_wired.switch_voice_prompts = &zone_wired_switch_voice_prompts;
+    device_zone_wired.switch_rotate_to_mute = &zone_wired_switch_rotate_to_mute;
 
     *device = &device_zone_wired;
 }
@@ -37,6 +41,20 @@ static int zone_wired_send_sidetone(hid_device* device_handle, uint8_t num)
     // The sidetone volume of the Zone Wired is configured in steps of 10%, with 0x00 = 0% and 0x0A = 100%
     uint8_t raw_volume = map(num, 0, 128, 0, 10);
     uint8_t data[MSG_SIZE] = { 0x22, 0xF1, 0x04, 0x00, 0x04, 0x3d, raw_volume, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+    return hid_send_feature_report(device_handle, data, MSG_SIZE);
+}
+
+static int zone_wired_switch_voice_prompts(hid_device* device_handle, uint8_t on)
+{
+    uint8_t data[MSG_SIZE] = { 0x22, 0xF1, 0x04, 0x00, 0x05, 0x3d, on, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+    return hid_send_feature_report(device_handle, data, MSG_SIZE);
+}
+
+static int zone_wired_switch_rotate_to_mute(hid_device* device_handle, uint8_t on)
+{
+    uint8_t data[MSG_SIZE] = { 0x22, 0xF1, 0x04, 0x00, 0x05, 0x6d, on, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     return hid_send_feature_report(device_handle, data, MSG_SIZE);
 }


### PR DESCRIPTION
Add support for the following two capabilities:

- `-v 0|1`: Enables or disables "voice prompts" (i.e. accoustic announcements like "mute on")
- `-r 0|1` Enables or disables "rotate to mute" (auto-mute the microphone when it's rotated upwards away from the mouth into a vertical position)

I've implemented both features for the Logitech Zone Wired (#140). I intentionally put this feature set into a different PR, as this is a global change, rather than simply a new device.