### PR TITLE
Allow to query for capabilities of current headset

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ You can reload udev configuration without reboot via `sudo udevadm control --rel
 Type `headsetcontrol -h` to get all available options.\
 (Don't forget to prefix it with `./` when the application resides in the current folder)
 
+Type `headsetcontrol -?` to get a list of supported capabilities for the currently detected headset
+
 `headsetcontrol -s 128` sets the sidetone to 128 (REAL loud). You can silence it with `0`. I recommend a loudness of 16.
 
 Following options don't work on all devices yet:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Following options don't work on all devices yet:
 
 `headsetcontrol -c` cut unnecessary output, for reading by other scripts or applications.
 
+`headsetcontrol -i 0-90` sets inactive time in minutes, time must be between 0 and 90, 0 disables the feature.
+
+`headsetcontrol -m` retrieves the current chat-mix-dial level setting.
+
 ### Third Party
 The following additional software can be used to enable control via a GUI
 

--- a/src/main.c
+++ b/src/main.c
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
             printf("  -n soundid\tMakes the headset play a notifiation\n");
             printf("  -l 0|1\tSwitch lights (0 = off, 1 = on)\n");
             printf("  -c\t\tCut unnecessary output \n");
-            printf("  -i time\tSets inactive time in minutes, level must be between 0 and 90, 0 disables the feature.\n");
+            printf("  -i time\tSets inactive time in minutes, time must be between 0 and 90, 0 disables the feature.\n");
             printf("  -m\t\tRetrieves the current chat-mix-dial level setting\n");
             printf("  -v 0|1\tTurn voice prompts on or off (0 = off, 1 = on)\n");
             printf("  -r 0|1\tTurn rotate to mute feature on or off (0 = off, 1 = on)\n");

--- a/src/main.c
+++ b/src/main.c
@@ -175,6 +175,17 @@ static char* get_hid_path(uint16_t vid, uint16_t pid, int iid, uint16_t usagepag
     return ret;
 }
 
+static void print_capability(enum capabilities cap, char shortName, const char* longName)
+{
+    if ((device_found.capabilities & cap) == cap) {
+        if (short_output) {
+            printf("%c", shortName);
+        } else {
+            printf("* %s\n", longName);
+        }
+    }
+}
+
 int main(int argc, char* argv[])
 {
     int c;
@@ -187,8 +198,9 @@ int main(int argc, char* argv[])
     long request_chatmix = 0;
     long voice_prompts = -1;
     long rotate_to_mute = -1;
+    long print_capabilities = -1;
 
-    while ((c = getopt(argc, argv, "bchs:n:l:i:mv:r:")) != -1) {
+    while ((c = getopt(argc, argv, "bchs:n:l:i:mv:r:?")) != -1) {
         switch (c) {
         case 'b':
             request_battery = 1;
@@ -243,6 +255,9 @@ int main(int argc, char* argv[])
                 printf("Usage: %s -r 0|1\n", argv[0]);
                 return 1;
             }
+            break;
+        case '?':
+            print_capabilities = 1;
             break;
         case 'h':
             printf("Headsetcontrol written by Sapd (Denis Arnst)\n\thttps://github.com/Sapd\n\n");
@@ -458,6 +473,19 @@ int main(int argc, char* argv[])
         }
 
         PRINT_INFO("Success!\n");
+    }
+
+    if (print_capabilities != -1) {
+        PRINT_INFO("Supported capabilities:\n\n");
+
+        print_capability(CAP_SIDETONE, 's', "set sidetone");
+        print_capability(CAP_BATTERY_STATUS, 'b', "read battery level");
+        print_capability(CAP_NOTIFICATION_SOUND, 'n', "play notification sound");
+        print_capability(CAP_LIGHTS, 'l', "switch lights");
+        print_capability(CAP_INACTIVE_TIME, 'i', "set inactive time");
+        print_capability(CAP_CHATMIX_STATUS, 'm', "read chat-mix");
+        print_capability(CAP_VOICE_PROMPTS, 'v', "set voice prompts");
+        print_capability(CAP_ROTATE_TO_MUTE, 'r', "set rotate to mute");
     }
 
     if (argc <= 1) {


### PR DESCRIPTION
When invoking headsetcontrol in other tools it would be useful to be able to dynamically adjust to the capabilities of the currently detected headset.

Therefore this PR adds a commandline option "-?" which prints out a list of things that will work for the current headset

```
$./headsetcontrol -?
Found SteelSeries Arctis (7/Pro)!

Supported capabilities:

* set sidetone
* read battery level
* switch lights
* set inactive time
* read chat-mix
```

Short output is also supported to make it easy to use this in other tools:

```
$./headsetcontrol -? -c
sblim
```
