### PR TITLE
Fix chat-mix comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Following options don't work on all devices yet:
 
 `headsetcontrol -i 0-90` sets inactive time in minutes, time must be between 0 and 90, 0 disables the feature.
 
-`headsetcontrol -m` retrieves the current chat-mix-dial level setting between 0 and 128. Below 64 is the chat side and above is the game side.
+`headsetcontrol -m` retrieves the current chat-mix-dial level setting between 0 and 128. Below 64 is the game side and above is the chat side.
 
 `headsetcontrol -u` Generates and outputs udev-rules for Linux.
 

--- a/src/main.c
+++ b/src/main.c
@@ -296,7 +296,7 @@ int main(int argc, char* argv[])
             printf("  -l 0|1\tSwitch lights (0 = off, 1 = on)\n");
             printf("  -c\t\tCut unnecessary output \n");
             printf("  -i time\tSets inactive time in minutes, time must be between 0 and 90, 0 disables the feature.\n");
-            printf("  -m\t\tRetrieves the current chat-mix-dial level setting between 0 and 128. Below 64 is the chat side and above is the game side.\n");
+            printf("  -m\t\tRetrieves the current chat-mix-dial level setting between 0 and 128. Below 64 is the game side and above is the chat side.\n");
             printf("  -v 0|1\tTurn voice prompts on or off (0 = off, 1 = on)\n");
             printf("  -r 0|1\tTurn rotate to mute feature on or off (0 = off, 1 = on)\n");
             printf("\n");


### PR DESCRIPTION
Fixed the chat-mix comments in readme and help menu.

-------

This was introduced in #171 by me. It seems I wrote the directions incorrectly, pardon me for that.