### PR TITLE
cmake improvements for distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ install(TARGETS headsetcontrol DESTINATION bin)
 # install udev files on linux
 if(UNIX AND NOT APPLE)
     set(rules_file 70-headsets.rules)
+    set(udev_rules_dir lib/udev/rules.d/
+        CACHE PATH "Path to the directory where udev rules should be installed")
     add_custom_command(
         OUTPUT ${rules_file}
         COMMAND headsetcontrol -u > ${rules_file}
@@ -128,7 +130,7 @@ if(UNIX AND NOT APPLE)
     add_custom_target(udevrules ALL DEPENDS ${rules_file})
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/${rules_file}
-        DESTINATION lib/udev/rules.d/)
+        DESTINATION ${udev_rules_dir})
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8...3.19)
-project(headsetcontrol)
+project(headsetcontrol LANGUAGES C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 set(CLANG_FORMAT_EXCLUDE_PATTERNS  "build/")


### PR DESCRIPTION
I'm maintaining HeadsetControl package for the distribution I use (ALT Sisyphus). While working on update to 2.5, I found that a couple of minor changes to `CMakeLists.txt` would make my job as a maintainer easier.

First, as most of (binary) distros do, we are building our package in a controlled environment that does not have a C++ compiler by default. Specifying that HeadsetControl is C-only project avoids the necessity to install it there.

Second, we're installing udev rules to `/lib/udev/rules.d`, which is not a symlink to  `/usr/lib/udev/rules.d` or anything like that. So I added an option to specify where CMake should put the udev rules file.