### PR TITLE
Arctis 1 Wireless - fixed inactive time functionality and added Windows Support

### DIFF
--- a/src/devices/steelseries_arctis_1.c
+++ b/src/devices/steelseries_arctis_1.c
@@ -29,9 +29,9 @@ void arctis_1_init(struct device** device)
     strncpy(device_arctis.device_name, "SteelSeries Arctis (1) Wireless", sizeof(device_arctis.device_name));
 
     device_arctis.capabilities                           = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME);
-    device_arctis.capability_details[CAP_SIDETONE]       = (struct capability_detail) { .usagepage=0xff43, .usageid=0x202, .interface = 0x03 };
-    device_arctis.capability_details[CAP_BATTERY_STATUS] = (struct capability_detail) { .usagepage=0xff43, .usageid=0x202, .interface = 0x03 };
-    device_arctis.capability_details[CAP_INACTIVE_TIME]  = (struct capability_detail) { .usagepage=0xff43, .usageid=0x202, .interface = 0x03 };
+    device_arctis.capability_details[CAP_SIDETONE]       = (struct capability_detail) { .usagepage = 0xff43, .usageid = 0x202, .interface = 0x03 };
+    device_arctis.capability_details[CAP_BATTERY_STATUS] = (struct capability_detail) { .usagepage = 0xff43, .usageid = 0x202, .interface = 0x03 };
+    device_arctis.capability_details[CAP_INACTIVE_TIME]  = (struct capability_detail) { .usagepage = 0xff43, .usageid = 0x202, .interface = 0x03 };
     device_arctis.send_sidetone                          = &arctis_1_send_sidetone;
     device_arctis.request_battery                        = &arctis_1_request_battery;
     device_arctis.send_inactive_time                     = &arctis_1_send_inactive_time;

--- a/src/devices/steelseries_arctis_1.c
+++ b/src/devices/steelseries_arctis_1.c
@@ -29,9 +29,9 @@ void arctis_1_init(struct device** device)
     strncpy(device_arctis.device_name, "SteelSeries Arctis (1) Wireless", sizeof(device_arctis.device_name));
 
     device_arctis.capabilities                           = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME);
-    device_arctis.capability_details[CAP_SIDETONE]       = (struct capability_detail) { .interface = 0x03 };
-    device_arctis.capability_details[CAP_BATTERY_STATUS] = (struct capability_detail) { .interface = 0x03 };
-    device_arctis.capability_details[CAP_INACTIVE_TIME]  = (struct capability_detail) { .interface = 0x03 };
+    device_arctis.capability_details[CAP_SIDETONE]       = (struct capability_detail) { .usagepage=0xff43, .usageid=0x202, .interface = 0x03 };
+    device_arctis.capability_details[CAP_BATTERY_STATUS] = (struct capability_detail) { .usagepage=0xff43, .usageid=0x202, .interface = 0x03 };
+    device_arctis.capability_details[CAP_INACTIVE_TIME]  = (struct capability_detail) { .usagepage=0xff43, .usageid=0x202, .interface = 0x03 };
     device_arctis.send_sidetone                          = &arctis_1_send_sidetone;
     device_arctis.request_battery                        = &arctis_1_request_battery;
     device_arctis.send_inactive_time                     = &arctis_1_send_inactive_time;

--- a/src/devices/steelseries_arctis_1.c
+++ b/src/devices/steelseries_arctis_1.c
@@ -112,7 +112,7 @@ static int arctis_1_send_inactive_time(hid_device* device_handle, uint8_t num)
     // the range of the Arctis 7 seems to be from 0 to 0x5A (90)
     // num = map(num, 0, 128, 0x00, 0x5A);
 
-    uint8_t data[31] = { 0x06, 0x51, num };
+    uint8_t data[31] = { 0x06, 0x53, num };
 
     int ret = hid_write(device_handle, data, 31);
 


### PR DESCRIPTION
Not sure if the addresses are different for the Xbox variant, but my Arctis 1 Wireless (firmware 1.6.0.0) uses 0x53 instead of 0x51 for setting the inactivity shutdown timer. 

Also added the correct usage page/ID for Windows support and it's completely functional on Windows now


