### PR TITLE
feat: add steelseries arctis 7 plus (2021) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
   - Sidetone, Battery, Inactive time
 - SteelSeries Arctis (7 and Pro)
   - Sidetone, Battery, Inactive time, Chat-Mix level, LED on/off (allows to turn off the blinking LED on the base-station)
+- SteelSeries Arctis 7+
+  - Sidetone, Battery, Inactive time
 - SteelSeries Arctis 9
   - Sidetone, Battery, Inactive time, Chat-Mix level
 - SteelSeries Arctis Pro Wireless

--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -12,12 +12,13 @@
 #include "devices/roccat_elo_7_1_usb.h"
 #include "devices/steelseries_arctis_1.h"
 #include "devices/steelseries_arctis_7.h"
+#include "devices/steelseries_arctis_7_plus.h"
 #include "devices/steelseries_arctis_9.h"
 #include "devices/steelseries_arctis_pro_wireless.h"
 
 #include <string.h>
 
-#define NUMDEVICES 14
+#define NUMDEVICES 15
 
 // array of pointers to device
 static struct device*(devicelist[NUMDEVICES]);
@@ -38,6 +39,7 @@ void init_devices()
     elo71Air_init(&devicelist[11]);
     g432_init(&devicelist[12]);
     elo71USB_init(&devicelist[13]);
+    arctis_7_plus_init(&devicelist[14]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_1.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7_plus.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_7_plus.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_pro_wireless.c

--- a/src/devices/steelseries_arctis_7_plus.c
+++ b/src/devices/steelseries_arctis_7_plus.c
@@ -1,0 +1,103 @@
+#include "../device.h"
+#include "../utility.h"
+
+#include <hidapi.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MSG_SIZE 64
+
+static struct device device_arctis;
+
+#define ID_ARCTIS_7_PLUS 0x220e
+
+#define BATTERY_MAX 0x04
+#define BATTERY_MIN 0x00
+
+#define HEADSET_OFFLINE 0x01
+
+static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_7_PLUS };
+
+static int arctis_7_plus_send_sidetone(hid_device* device_handle, uint8_t num);
+static int arctis_7_plus_send_inactive_time(hid_device* device_handle, uint8_t num);
+static int arctis_7_plus_request_battery(hid_device* device_handle);
+
+int arctis_7_plus_read_device_status(hid_device* device_handle, unsigned char* data_read);
+
+void arctis_7_plus_init(struct device** device)
+{
+    device_arctis.idVendor            = VENDOR_STEELSERIES;
+    device_arctis.idProductsSupported = PRODUCT_IDS;
+    device_arctis.numIdProducts       = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+
+    strncpy(device_arctis.device_name, "SteelSeries Arctis 7+", sizeof(device_arctis.device_name));
+
+    device_arctis.capabilities                           = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME);
+    device_arctis.capability_details[CAP_SIDETONE]       = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+    device_arctis.capability_details[CAP_BATTERY_STATUS] = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+    device_arctis.capability_details[CAP_INACTIVE_TIME]  = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+
+    device_arctis.send_sidetone      = &arctis_7_plus_send_sidetone;
+    device_arctis.request_battery    = &arctis_7_plus_request_battery;
+    device_arctis.send_inactive_time = &arctis_7_plus_send_inactive_time;
+
+    *device = &device_arctis;
+}
+
+static int arctis_7_plus_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    // num, will be from 0 to 128, we need to map it to the correct value
+    // the range of the Arctis 7+ is from 0 to 3
+    num = map(num, 0, 128, 0, 3);
+
+    uint8_t data[MSG_SIZE] = { 0x00, 0x39, num };
+
+    return hid_write(device_handle, data, MSG_SIZE);
+}
+
+static int arctis_7_plus_send_inactive_time(hid_device* device_handle, uint8_t num)
+{
+    // as the value is in minutes, mapping to a different range does not make too much sense here
+    // the range of the Arctis 7+ is from 0 to 0x5A (90)
+
+    uint8_t data[MSG_SIZE] = { 0x00, 0xa3, num };
+
+    return hid_write(device_handle, data, MSG_SIZE);
+}
+
+static int arctis_7_plus_request_battery(hid_device* device_handle)
+{
+    // read device info
+    unsigned char data_read[6];
+    int r = arctis_7_plus_read_device_status(device_handle, data_read);
+
+    if (r < 0)
+        return r;
+
+    if (r == 0)
+        return HSC_READ_TIMEOUT;
+
+    if (data_read[1] == HEADSET_OFFLINE)
+        return BATTERY_UNAVAILABLE;
+
+    if (data_read[3] == 0x01)
+        return BATTERY_CHARGING;
+
+    int bat = data_read[2];
+
+    if (bat > BATTERY_MAX)
+        return 100;
+
+    return map(bat, BATTERY_MIN, BATTERY_MAX, 0, 100);
+}
+
+int arctis_7_plus_read_device_status(hid_device* device_handle, unsigned char* data_read)
+{
+    unsigned char data_request[2] = { 0x00, 0xb0 };
+    int r                         = hid_write(device_handle, data_request, 2);
+
+    if (r < 0)
+        return r;
+
+    return hid_read_timeout(device_handle, data_read, 6, hsc_device_timeout);
+}

--- a/src/devices/steelseries_arctis_7_plus.h
+++ b/src/devices/steelseries_arctis_7_plus.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void arctis_7_plus_init(struct device** device);


### PR DESCRIPTION
This adds Steelseries Arctis 7 Plus support for side tone and inactive time (tested). 
~I couldn't find in wireshark any info regarding battery status so this is skipped for now. I would welcome help though in this matter.~

Additionally this model support a few Equalizer presets (also custom settings) that I can successfully change via following commands:

```sh
# flat
./headsetcontrol --dev -- --device 0x1038:0x220e --interface 3 --send "0x0, 0x33, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 00"

# bass boost
./headsetcontrol --dev -- --device 0x1038:0x220e --interface 3 --send "0x0, 0x33, 0x1f, 0x20, 0x1a, 0x15, 0x15, 0x16, 0x16, 0x16, 0x16, 0x23, 00"

# smily
./headsetcontrol --dev -- --device 0x1038:0x220e --interface 3 --send "0x0, 0x33, 0x1e, 0x1b, 0x15, 0x10, 0x10, 0x13, 0x1b, 0x1e, 0x20, 0x1f, 00"

# focus
./headsetcontrol --dev -- --device 0x1038:0x220e --interface 3 --send "0x0, 0x33, 0x0e, 0x16, 0x11, 0x13, 0x20, 0x24, 0x1f, 0x11, 0x18, 0x11, 00"
```

I can add this to the project if you are interested in supporting EQ.