### PR TITLE
Add inactive_timeout for g533

### DIFF
--- a/src/devices/logitech_g533.c
+++ b/src/devices/logitech_g533.c
@@ -13,6 +13,7 @@ static const uint16_t PRODUCT_ID = 0x0a66;
 
 static int g533_send_sidetone(hid_device* device_handle, uint8_t num);
 static int g533_request_battery(hid_device* device_handle);
+static int g533_send_inactive_time(hid_device* device_handle, uint8_t num);
 
 void g533_init(struct device** device)
 {
@@ -22,11 +23,13 @@ void g533_init(struct device** device)
 
     strncpy(device_g533.device_name, "Logitech G533", sizeof(device_g533.device_name));
 
-    device_g533.capabilities                           = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS);
+    device_g533.capabilities                           = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME);
     device_g533.capability_details[CAP_SIDETONE]       = (struct capability_detail) { .usagepage = 0xff00, .usageid = 0x1, .interface = 3 };
     device_g533.capability_details[CAP_BATTERY_STATUS] = (struct capability_detail) { .usagepage = 0xff43, .usageid = 0x202, .interface = 3 };
+    device_g533.capability_details[CAP_INACTIVE_TIME]  = (struct capability_detail) { .usagepage = 0xff43, .usageid = 0x0202 };
     device_g533.request_battery                        = &g533_request_battery;
     device_g533.send_sidetone                          = &g533_send_sidetone;
+    device_g533.send_inactive_time                     = &g533_send_inactive_time;
 
     *device = &device_g533;
 }
@@ -103,4 +106,39 @@ static int g533_request_battery(hid_device* device_handle)
 #endif
 
     return estimate_battery_level(voltage);
+}
+
+static int g533_send_inactive_time(hid_device* device_handle, uint8_t num)
+{
+    /*
+        CREDIT GOES TO https://github.com/ashkitten/ for the project
+        https://github.com/ashkitten/g933-utils/
+        I've simply ported that implementation to this project!
+    */
+
+    int r = 0;
+    // request battery voltage
+    uint8_t data_request[HIDPP_LONG_MESSAGE_LENGTH] = { HIDPP_LONG_MESSAGE, HIDPP_DEVICE_RECEIVER, 0x07, 0x21, num };
+
+    r = hid_write(device_handle, data_request, HIDPP_LONG_MESSAGE_LENGTH);
+    if (r < 0)
+        return r;
+
+    uint8_t data_read[7];
+    r = hid_read_timeout(device_handle, data_read, 7, hsc_device_timeout);
+    if (r < 0)
+        return r;
+
+    if (r == 0)
+        return HSC_READ_TIMEOUT;
+
+    // Headset offline
+    if (data_read[2] == 0xFF)
+        return HSC_ERROR;
+
+#ifdef DEBUG
+    printf("G33 - g533_send_inactive_time - b1: 0x%08x\n", data_read[4]);
+#endif
+
+    return r;
 }


### PR DESCRIPTION
This adds inactive timeout for g533, based on the g933-utils repository.

I've left the comments about the repository source, as this also draws upon that for the specification.
