### PR TITLE
steelseries arctis nova 7 support for battery read and sidetone

### DIFF
--- a/src/device_registry.c
+++ b/src/device_registry.c
@@ -17,10 +17,11 @@
 #include "devices/steelseries_arctis_7_plus.h"
 #include "devices/steelseries_arctis_9.h"
 #include "devices/steelseries_arctis_pro_wireless.h"
+#include "devices/steelseries_arctis_nova_7.h"
 
 #include <string.h>
 
-#define NUMDEVICES 17
+#define NUMDEVICES 18
 
 // array of pointers to device
 static struct device*(devicelist[NUMDEVICES]);
@@ -36,14 +37,15 @@ void init_devices()
     arctis_7_init(&devicelist[6]);
     arctis_9_init(&devicelist[7]);
     arctis_pro_wireless_init(&devicelist[8]);
-    gpro_init(&devicelist[9]);
-    zone_wired_init(&devicelist[10]);
-    elo71Air_init(&devicelist[11]);
-    g432_init(&devicelist[12]);
-    elo71USB_init(&devicelist[13]);
-    arctis_7_plus_init(&devicelist[14]);
-    cflight_init(&devicelist[15]);
-    g535_init(&devicelist[16]);
+    arctis_nova_7_init(&devicelist[9]);
+    gpro_init(&devicelist[10]);
+    zone_wired_init(&devicelist[11]);
+    elo71Air_init(&devicelist[12]);
+    g432_init(&devicelist[13]);
+    elo71USB_init(&devicelist[14]);
+    arctis_7_plus_init(&devicelist[15]);
+    cflight_init(&devicelist[16]);
+    g535_init(&devicelist[17]);
 }
 
 int get_device(struct device* device_found, uint16_t idVendor, uint16_t idProduct)

--- a/src/devices/CMakeLists.txt
+++ b/src/devices/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_9.h
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_pro_wireless.c
     ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_pro_wireless.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_nova_7.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/steelseries_arctis_nova_7.h
     ${CMAKE_CURRENT_SOURCE_DIR}/roccat_elo_7_1_air.h
     ${CMAKE_CURRENT_SOURCE_DIR}/roccat_elo_7_1_air.c
     ${CMAKE_CURRENT_SOURCE_DIR}/roccat_elo_7_1_usb.h

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -1,0 +1,121 @@
+#include "../device.h"
+#include "../utility.h"
+
+#include <hidapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MSG_SIZE 64
+
+static struct device device_arctis;
+
+#define ID_arctis_nova_7     0x2202
+
+#define BATTERY_MAX 0x04
+#define BATTERY_MIN 0x00
+
+#define HEADSET_OFFLINE 0x00
+
+static const uint16_t PRODUCT_IDS[] = { ID_arctis_nova_7 };
+
+static int arctis_nova_7_send_sidetone(hid_device* device_handle, uint8_t num);
+static int arctis_nova_7_send_inactive_time(hid_device* device_handle, uint8_t num);
+static int arctis_nova_7_send_equalizer_preset(hid_device* device_handle, uint8_t num);
+static int arctis_nova_7_request_battery(hid_device* device_handle);
+
+int arctis_nova_7_read_device_status(hid_device* device_handle, unsigned char* data_read);
+
+void arctis_nova_7_init(struct device** device)
+{
+    device_arctis.idVendor            = VENDOR_STEELSERIES;
+    device_arctis.idProductsSupported = PRODUCT_IDS;
+    device_arctis.numIdProducts       = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+
+    strncpy(device_arctis.device_name, "SteelSeries Arctis Nova 7", sizeof(device_arctis.device_name));
+
+    device_arctis.capabilities                             = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME) | B(CAP_EQUALIZER_PRESET);
+    device_arctis.capability_details[CAP_SIDETONE]         = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+    device_arctis.capability_details[CAP_BATTERY_STATUS]   = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+    device_arctis.capability_details[CAP_INACTIVE_TIME]    = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+    device_arctis.capability_details[CAP_EQUALIZER_PRESET] = (struct capability_detail) { .usagepage = 0xffc0, .usageid = 0x1, .interface = 3 };
+
+    device_arctis.send_sidetone         = &arctis_nova_7_send_sidetone;
+    device_arctis.request_battery       = &arctis_nova_7_request_battery;
+    device_arctis.send_inactive_time    = &arctis_nova_7_send_inactive_time;
+    device_arctis.send_equalizer_preset = &arctis_nova_7_send_equalizer_preset;
+
+    *device = &device_arctis;
+}
+
+static int arctis_nova_7_send_sidetone(hid_device* device_handle, uint8_t num)
+{
+    if (num < 26) {
+        num = 0x0;
+    } else if (num < 51) {
+        num = 0x1;
+    } else if (num < 76) {
+        num = 0x2;
+    } else {
+        num = 0x3;
+    }
+
+    uint8_t data[MSG_SIZE] = { 0x00, 0x39, num };
+
+    return hid_write(device_handle, data, MSG_SIZE);
+}
+
+static int arctis_nova_7_send_inactive_time(hid_device* device_handle, uint8_t num)
+{
+    return 0;
+}
+
+static int arctis_nova_7_request_battery(hid_device* device_handle)
+{
+    // read device info
+    unsigned char data_read[6];
+    int r = arctis_nova_7_read_device_status(device_handle, data_read);
+
+//developer corner
+    /*char tmp[128];
+    size_t rc = hexdump(tmp, sizeof(tmp), data_read, sizeof(data_read));
+    printf("rc: %zx, %s\n", rc, tmp);*/
+
+// data_read[1] has state 0x03 when headphones are power on and 0x02 when off
+// data_read[5] and data_read[6] offline state [0xff, 0xff] when power on [0x64, 0x64]
+
+    if (r < 0)
+        return r;
+
+    if (r == 0)
+        return HSC_READ_TIMEOUT;
+
+    if (data_read[3] == HEADSET_OFFLINE)
+        return BATTERY_UNAVAILABLE;
+
+    if (data_read[3] == 0x01)
+        return BATTERY_CHARGING;
+
+    int bat = data_read[2];
+
+    if (bat > BATTERY_MAX)
+        return 100;
+
+    return map(bat, BATTERY_MIN, BATTERY_MAX, 0, 100);
+}
+
+static int arctis_nova_7_send_equalizer_preset(hid_device* device_handle, uint8_t num)
+{
+    return HSC_OUT_OF_BOUNDS;
+}
+
+int arctis_nova_7_read_device_status(hid_device* device_handle, unsigned char* data_read)
+{
+    unsigned char data_request[2] = { 0x00, 0xb0 };
+    int r = hid_write(device_handle, data_request, 2);
+
+    if (r < 0)
+        return r;
+
+    return hid_read_timeout(device_handle, data_read, 6, hsc_device_timeout);
+}

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -68,6 +68,21 @@ static int arctis_nova_7_send_sidetone(hid_device* device_handle, uint8_t num)
 static int arctis_nova_7_send_inactive_time(hid_device* device_handle, uint8_t num)
 {
     return 0;
+    uint8_t data[MSG_SIZE] = { 0x00, 0xa3, num };
+    /*
+     * During setting this part headphones my lose paring with transmitter, to fix this issue follow instruction in this link
+     * https://support.steelseries.com/hc/en-us/articles/115000051472-The-SteelSeries-Engine-says-Reconnect-Headset-but-my-transmitter-is-connected-
+     *
+     0x00 never
+     0x01 1m
+     0x05 5m
+     0x0a 10m
+     0x0f 15m
+     0x1e 30m
+     0x2d 45m
+     */
+
+    return hid_write(device_handle, data, MSG_SIZE);
 }
 
 static int arctis_nova_7_request_battery(hid_device* device_handle)
@@ -106,7 +121,30 @@ static int arctis_nova_7_request_battery(hid_device* device_handle)
 
 static int arctis_nova_7_send_equalizer_preset(hid_device* device_handle, uint8_t num)
 {
-    return HSC_OUT_OF_BOUNDS;
+    // flat (default), bass boost, smiley, focus
+
+    switch (num) {
+    case 0: {
+        uint8_t flat[MSG_SIZE] = { 0x0, 0x33, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x0 };
+        return hid_write(device_handle, flat, MSG_SIZE);
+    }
+    case 1: {
+        uint8_t bass[MSG_SIZE] = { 0x0, 0x33, 0x1b, 0x1f, 0x1c, 0x16, 0x11, 0x11, 0x12, 0x12, 0x12, 0x12, 0x0 };
+        return hid_write(device_handle, bass, MSG_SIZE);
+    }
+    case 2: {
+        uint8_t smiley[MSG_SIZE] = { 0x0, 0x33, 0x0a, 0x0d, 0x12, 0x0d, 0x0f, 0x1c, 0x20, 0x1b, 0x0d, 0x14, 0x0 };
+        return hid_write(device_handle, smiley, MSG_SIZE);
+    }
+    case 3: {
+        uint8_t focus[MSG_SIZE] = { 0x0, 0x33, 0x1a, 0x1b, 0x17, 0x11, 0x0c, 0x0c, 0x0f, 0x17, 0x1a, 0x1c, 0x0 };
+        return hid_write(device_handle, focus, MSG_SIZE);
+    }
+    default: {
+        printf("Device only supports 0-3 range for presets.\n");
+        return HSC_OUT_OF_BOUNDS;
+    }
+    }
 }
 
 int arctis_nova_7_read_device_status(hid_device* device_handle, unsigned char* data_read)

--- a/src/devices/steelseries_arctis_nova_7.h
+++ b/src/devices/steelseries_arctis_nova_7.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void arctis_nova_7_init(struct device** device);
+


### PR DESCRIPTION
Initial support for steelseries arctis nova 7, tested with headset-charge-indicator.