### PR TITLE
s9 only supports a single report, first byte must be set to 0x0

### DIFF
--- a/src/devices/steelseries_arctis_9.c
+++ b/src/devices/steelseries_arctis_9.c
@@ -59,8 +59,8 @@ static int arctis_9_send_sidetone(hid_device* device_handle, uint8_t num)
         return ret;
     }
 
-    const unsigned char data_on[5]  = { 0x06, 0x00, num };
-    const unsigned char data_off[3] = { 0x06, 0x00, 0xc0 };
+    const unsigned char data_on[5]  = { 0x0, 0x06, num };
+    const unsigned char data_off[3] = { 0x0, 0x06, 0xc0 };
 
     if (num) {
         memmove(buf, data_on, sizeof(data_on));
@@ -106,7 +106,7 @@ static int arctis_9_send_inactive_time(hid_device* device_handle, uint8_t num)
 {
     // the value for the Arctis 9 needs to be in seconds
     uint32_t time    = num * 60;
-    uint8_t data[31] = { 0x04, 0x00, (uint8_t)(time >> 8), (uint8_t)(time) };
+    uint8_t data[31] = { 0x0, 0x04, (uint8_t)(time >> 8), (uint8_t)(time) };
 
     int ret = hid_write(device_handle, data, 31);
 
@@ -137,7 +137,7 @@ static int arctis_9_request_chatmix(hid_device* device_handle)
 
 int arctis_9_save_state(hid_device* device_handle)
 {
-    uint8_t data[31] = { 0x90, 0x00 };
+    uint8_t data[31] = { 0x0, 0x90 };
 
     return hid_write(device_handle, data, 31);
 }
@@ -146,7 +146,7 @@ int arctis_9_read_device_status(hid_device* device_handle, unsigned char* data_r
 {
     int r = 0;
 
-    unsigned char data_request[2] = { 0x20, 0x20 };
+    unsigned char data_request[2] = { 0x0, 0x20 };
     r                             = hid_write(device_handle, data_request, 2);
 
     if (r < 0)


### PR DESCRIPTION
System Information: 
```
rscott@home ~ $ udevadm info --query=all /sys/devices/pci0000:00/0000:00:14.0/usb3/3-5/3-5.2/
P: /devices/pci0000:00/0000:00:14.0/usb3/3-5/3-5.2
M: 3-5.2
R: 2
U: usb
T: usb_device
D: c 189:272
N: bus/usb/003/017
L: 0
V: usb
E: DEVPATH=/devices/pci0000:00/0000:00:14.0/usb3/3-5/3-5.2
E: SUBSYSTEM=usb
E: DEVNAME=/dev/bus/usb/003/017
E: DEVTYPE=usb_device
E: DRIVER=usb
E: PRODUCT=1038/12c2/74
E: TYPE=0/0/0
E: BUSNUM=003
E: DEVNUM=017
E: MAJOR=189
E: MINOR=272
E: USEC_INITIALIZED=10274180
E: ID_VENDOR=SteelSeries
E: ID_VENDOR_ENC=SteelSeries
E: ID_VENDOR_ID=1038
E: ID_MODEL=SteelSeries_Arctis_9
E: ID_MODEL_ENC=SteelSeries\x20Arctis\x209
E: ID_MODEL_ID=12c2
E: ID_REVISION=0074
E: ID_SERIAL=SteelSeries_SteelSeries_Arctis_9
E: ID_BUS=usb
E: ID_USB_INTERFACES=:030000:
E: ID_VENDOR_FROM_DATABASE=SteelSeries ApS
E: ID_PATH=pci-0000:00:14.0-usb-0:5.2
E: ID_PATH_TAG=pci-0000_00_14_0-usb-0_5_2
E: ID_FOR_SEAT=usb-pci-0000_00_14_0-usb-0_5_2
E: TAGS=:seat:
E: CURRENT_TAGS=:seat:
```
```
rscott@home ~ $ sudo emerge \=dev-libs/hidapi-0.11.0 -av

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R    ] dev-libs/hidapi-0.11.0::gentoo  USE="doc (-fox)" ABI_X86="(64) -32 (-x32)" 0 KiB

Total: 1 package (1 reinstall), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No]
```
```
rscott@home ~ $ lsusb | grep SteelSeries
Bus 003 Device 017: ID 1038:12c2 SteelSeries ApS SteelSeries Arctis 9
Bus 003 Device 019: ID 1038:12c4 SteelSeries ApS SteelSeries Arctis 9
```
```
rscott@home ~ $ uname -a
Linux home 6.0.12-zen1-x86_64 #1 ZEN SMP PREEMPT_DYNAMIC Thu Dec 29 15:31:50 GMT 2022 x86_64 Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz GenuineIntel GNU/Linux
# Gentoo Linux
```

I wanted to retrieve battery percentage - kept timing out.

When debugging function `arctis_9_read_device_status`,
I found out that Report ID '20x0',
was the same as Report DATA '20x0'.
I changed the first byte to 0x0 and it worked.

I read online that the Report ID must be 0x0 for devices which only support a single report
http://hidapi-d.dpldocs.info/hidapi.bindings.hid_write.html

I went a step further and changed all bytes to 0x0 (and swapped some with the second byte), and this worked.

I sense there is perhaps some deprecation with newer versions of hidapi?