### PR TITLE
Add Support for Arctis 7X+ (Xbox)

### DIFF
--- a/src/devices/steelseries_arctis_7_plus.c
+++ b/src/devices/steelseries_arctis_7_plus.c
@@ -10,8 +10,9 @@
 
 static struct device device_arctis;
 
-#define ID_ARCTIS_7_PLUS     0x220e
-#define ID_ARCTIS_7_PLUS_PS5 0x2212
+#define ID_ARCTIS_7_PLUS      0x220e
+#define ID_ARCTIS_7_PLUS_PS5  0x2212
+#define ID_ARCTIS_7_PLUS_XBOX 0x2216
 
 #define BATTERY_MAX 0x04
 #define BATTERY_MIN 0x00
@@ -21,7 +22,7 @@ static struct device device_arctis;
 
 #define EQUALIZER_BANDS_SIZE 10
 
-static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_7_PLUS, ID_ARCTIS_7_PLUS_PS5 };
+static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_7_PLUS, ID_ARCTIS_7_PLUS_PS5, ID_ARCTIS_7_PLUS_XBOX };
 
 static int arctis_7_plus_send_sidetone(hid_device* device_handle, uint8_t num);
 static int arctis_7_plus_send_inactive_time(hid_device* device_handle, uint8_t num);


### PR DESCRIPTION
Adds support for the XBox version of the Arctis 7+ using a different device id(ID 1038:2216 SteelSeries ApS Arctis 7X+)