### PR TITLE
Added new device ID for G733

### DIFF
--- a/src/devices/logitech_g633_g933_935.c
+++ b/src/devices/logitech_g633_g933_935.c
@@ -14,8 +14,10 @@ static struct device device_g933_935;
 #define ID_LOGITECH_G933 0x0a5b
 #define ID_LOGITECH_G935 0x0a87
 #define ID_LOGITECH_G733 0x0ab5
+#define ID_LOGITECH_G733_2 0x0afe
 
-static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733 };
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733, ID_LOGITECH_G733_2 };
 
 static int g933_935_send_sidetone(hid_device* device_handle, uint8_t num);
 static int g933_935_request_battery(hid_device* device_handle);
@@ -26,7 +28,7 @@ void g933_935_init(struct device** device)
     device_g933_935.idVendor            = VENDOR_LOGITECH;
     device_g933_935.idProductsSupported = PRODUCT_IDS;
     device_g933_935.numIdProducts       = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
-    strncpy(device_g933_935.device_name, "Logitech G633/G635/G933/G935", sizeof(device_g933_935.device_name));
+    strncpy(device_g933_935.device_name, "Logitech G633/G635/G733/G933/G935", sizeof(device_g933_935.device_name));
 
     device_g933_935.capabilities = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_LIGHTS);
     /// TODO: usagepages and ids may not be correct for all features


### PR DESCRIPTION
The actual Logitech G733 has new Device ID "ID 046d:0afe Logitech, Inc. G733 Gaming Headset"

Modifying code to add the ID and update the name to show "G733" too.