### PR TITLE
Add new ID Logitech G733

### DIFF
--- a/src/devices/logitech_g633_g933_935.c
+++ b/src/devices/logitech_g633_g933_935.c
@@ -9,13 +9,12 @@
 
 static struct device device_g933_935;
 
-#define ID_LOGITECH_G633 0x0a5c
-#define ID_LOGITECH_G635 0x0a89
-#define ID_LOGITECH_G933 0x0a5b
-#define ID_LOGITECH_G935 0x0a87
-#define ID_LOGITECH_G733 0x0ab5
+#define ID_LOGITECH_G633   0x0a5c
+#define ID_LOGITECH_G635   0x0a89
+#define ID_LOGITECH_G933   0x0a5b
+#define ID_LOGITECH_G935   0x0a87
+#define ID_LOGITECH_G733   0x0ab5
 #define ID_LOGITECH_G733_2 0x0afe
-
 
 static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733, ID_LOGITECH_G733_2 };
 
@@ -77,7 +76,7 @@ static int g933_935_request_battery(hid_device* device_handle)
     if (r == 0)
         return HSC_READ_TIMEOUT;
 
-    //6th byte is state; 0x1 for idle, 0x3 for charging
+    // 6th byte is state; 0x1 for idle, 0x3 for charging
     uint8_t state = data_read[6];
     if (state == 0x03)
         return BATTERY_CHARGING;

--- a/src/devices/logitech_g633_g933_935.c
+++ b/src/devices/logitech_g633_g933_935.c
@@ -14,8 +14,10 @@ static struct device device_g933_935;
 #define ID_LOGITECH_G933 0x0a5b
 #define ID_LOGITECH_G935 0x0a87
 #define ID_LOGITECH_G733 0x0ab5
+#define ID_LOGITECH_G733_2 0x0afe
 
-static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733 };
+
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733, ID_LOGITECH_G733_2 };
 
 static int g933_935_send_sidetone(hid_device* device_handle, uint8_t num);
 static int g933_935_request_battery(hid_device* device_handle);
@@ -26,7 +28,7 @@ void g933_935_init(struct device** device)
     device_g933_935.idVendor            = VENDOR_LOGITECH;
     device_g933_935.idProductsSupported = PRODUCT_IDS;
     device_g933_935.numIdProducts       = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
-    strncpy(device_g933_935.device_name, "Logitech G633/G635/G933/G935", sizeof(device_g933_935.device_name));
+    strncpy(device_g933_935.device_name, "Logitech G633/G635/G733/G933/G935", sizeof(device_g933_935.device_name));
 
     device_g933_935.capabilities = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_LIGHTS);
     /// TODO: usagepages and ids may not be correct for all features


### PR DESCRIPTION
New Logitech G733 has diferent DEVICE ID
Example: ID 046d:0afe Logitech, Inc. G733 Gaming Headset

Added ID and name
