### PR TITLE
Support for 0x0a56(Corsair Void Elite USB RGB)

### DIFF
--- a/src/devices/corsair_void.c
+++ b/src/devices/corsair_void.c
@@ -27,6 +27,8 @@ enum void_wireless_battery_flags {
 #define ID_CORSAIR_HS70_PRO                        0x0a4f
 #define ID_CORSAIR_VOID_RGB_WIRELESS               0x0a2b
 #define ID_CORSAIR_VOID_ELITE_WIRELESS_PREMIUM_RGB 0x0a75
+#define ID_CORSAIR_VOID_ELITE_USB_RGB              0x0a56
+
 
 static const uint16_t PRODUCT_IDS[] = {
     ID_CORSAIR_VOID_RGB_WIRED,
@@ -46,6 +48,7 @@ static const uint16_t PRODUCT_IDS[] = {
     ID_CORSAIR_HS70_PRO,
     ID_CORSAIR_VOID_RGB_WIRELESS,
     ID_CORSAIR_VOID_ELITE_WIRELESS_PREMIUM_RGB,
+    ID_CORSAIR_VOID_ELITE_USB_RGB,
 };
 
 static int void_send_sidetone(hid_device* device_handle, uint8_t num);


### PR DESCRIPTION
While there is a entry for Corsair Void Elite USB. The RGB version seems to have a separate id.