### PR TITLE
Introduce internal equalizer baseline and band limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
   - Sidetone, Battery
 - SteelSeries Arctis 1, Arctis 1 for XBox
   - Sidetone, Battery, Inactive time
+- SteelSeries Arctis Nova 3
+  - Sidetone, Equalizer Presets, Equalizer, Microphone Mute LED Brightness, Microphone Volume
 - SteelSeries Arctis (7 and Pro)
   - Sidetone, Battery, Inactive time, Chat-Mix level, LED on/off (allows to turn off the blinking LED on the base-station)
 - SteelSeries Arctis 7+

--- a/src/dev.c
+++ b/src/dev.c
@@ -173,8 +173,8 @@ int dev_main(int argc, char* argv[])
     int print_deviceinfo = 0;
 
 #define BUFFERLENGTH 1024
-    char* sendbuffer       = calloc(BUFFERLENGTH, sizeof(char));
-    char* sendreportbuffer = calloc(BUFFERLENGTH, sizeof(char));
+    unsigned char* sendbuffer       = calloc(BUFFERLENGTH, sizeof(char));
+    unsigned char* sendreportbuffer = calloc(BUFFERLENGTH, sizeof(char));
 
     unsigned char* receivebuffer       = malloc(sizeof(char) * BUFFERLENGTH);
     unsigned char* receivereportbuffer = malloc(sizeof(char) * BUFFERLENGTH);
@@ -240,7 +240,7 @@ int dev_main(int argc, char* argv[])
             break;
         }
         case 's': { // --send string
-            int size = get_data_from_parameter(optarg, sendbuffer, BUFFERLENGTH);
+            int size = get_byte_data_from_parameter(optarg, sendbuffer, BUFFERLENGTH);
 
             if (size < 0) {
                 fprintf(stderr, "Data to send larger than %d\n", BUFFERLENGTH);
@@ -257,7 +257,7 @@ int dev_main(int argc, char* argv[])
             break;
         }
         case 'f': { // --send-feature string
-            int size = get_data_from_parameter(optarg, sendreportbuffer, BUFFERLENGTH);
+            int size = get_byte_data_from_parameter(optarg, sendreportbuffer, BUFFERLENGTH);
 
             if (size < 0) {
                 fprintf(stderr, "Data to send for feature report larger than %d\n", BUFFERLENGTH);

--- a/src/device.h
+++ b/src/device.h
@@ -68,7 +68,7 @@ struct equalizer_settings {
     /// The size of the bands array
     int size;
     /// The equalizer frequency bands values
-    char bands_values[];
+    float bands_values[];
 };
 
 /** @brief Defines the basic data of a device

--- a/src/devices/steelseries_arctis_7_plus.c
+++ b/src/devices/steelseries_arctis_7_plus.c
@@ -22,6 +22,9 @@ static struct device device_arctis;
 #define STATUS_BUF_SIZE 6
 
 #define EQUALIZER_BANDS_SIZE 10
+#define EQUALIZER_BASELINE   0x18
+#define EQUALIZER_BAND_MIN   -12
+#define EQUALIZER_BAND_MAX   +12
 
 static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_7_PLUS, ID_ARCTIS_7_PLUS_PS5, ID_ARCTIS_7_PLUS_XBOX, ID_ARCTIS_7_PLUS_DESTINY };
 
@@ -186,7 +189,13 @@ static int arctis_7_plus_send_equalizer(hid_device* device_handle, struct equali
 
     uint8_t data[MSG_SIZE] = { 0x0, 0x33 };
     for (int i = 0; i < settings->size; i++) {
-        data[i + 2] = (uint8_t)settings->bands_values[i];
+        float band_value = settings->bands_values[i];
+        if (band_value < EQUALIZER_BAND_MIN || band_value > EQUALIZER_BAND_MAX) {
+            printf("Device only supports bands ranging from %d to %d.\n", EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX);
+            return HSC_OUT_OF_BOUNDS;
+        }
+
+        data[i + 2] = (uint8_t)(EQUALIZER_BASELINE + 2 * band_value);
     }
     data[settings->size + 3] = 0x0;
 

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -22,6 +22,9 @@ static struct device device_arctis;
 #define STATUS_BUF_SIZE 8
 
 #define EQUALIZER_BANDS_SIZE 10
+#define EQUALIZER_BASELINE   0x14
+#define EQUALIZER_BAND_MIN   -10
+#define EQUALIZER_BAND_MAX   +10
 
 static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV };
 
@@ -188,7 +191,13 @@ static int arctis_nova_7_send_equalizer(hid_device* device_handle, struct equali
 
     uint8_t data[MSG_SIZE] = { 0x0, 0x33 };
     for (int i = 0; i < settings->size; i++) {
-        data[i + 2] = (uint8_t)settings->bands_values[i];
+        float band_value = settings->bands_values[i];
+        if (band_value < EQUALIZER_BAND_MIN || band_value > EQUALIZER_BAND_MAX) {
+            printf("Device only supports bands ranging from %d to %d.\n", EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX);
+            return HSC_OUT_OF_BOUNDS;
+        }
+
+        data[i + 2] = (uint8_t)(EQUALIZER_BASELINE + band_value);
     }
     data[settings->size + 3] = 0x0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -310,7 +310,7 @@ int main(int argc, char* argv[])
     struct equalizer_settings* equalizer = NULL;
 
 #define BUFFERLENGTH 1024
-    char* read_buffer = calloc(BUFFERLENGTH, sizeof(char));
+    float* read_buffer = calloc(BUFFERLENGTH, sizeof(float));
 
     struct option opts[] = {
         { "battery", no_argument, NULL, 'b' },
@@ -350,7 +350,7 @@ int main(int argc, char* argv[])
             short_output = 1;
             break;
         case 'e': {
-            int size = get_data_from_parameter(optarg, read_buffer, BUFFERLENGTH);
+            int size = get_float_data_from_parameter(optarg, read_buffer, BUFFERLENGTH);
 
             if (size < 0) {
                 fprintf(stderr, "Equalizer bands values size larger than supported %d\n", BUFFERLENGTH);
@@ -362,7 +362,7 @@ int main(int argc, char* argv[])
                 return 1;
             }
 
-            equalizer       = malloc(sizeof(struct equalizer_settings) + size * sizeof(char));
+            equalizer       = malloc(sizeof(struct equalizer_settings) + size * sizeof(float));
             equalizer->size = size;
             for (int i = 0; i < size; i++) {
                 equalizer->bands_values[i] = read_buffer[i];
@@ -454,7 +454,7 @@ int main(int argc, char* argv[])
             printf("  -m, --chatmix\t\t\tRetrieves the current chat-mix-dial level setting between 0 and 128. Below 64 is the game side and above is the chat side.\n");
             printf("  -v, --voice-prompt 0|1\tTurn voice prompts on or off (0 = off, 1 = on)\n");
             printf("  -r, --rotate-to-mute 0|1\tTurn rotate to mute feature on or off (0 = off, 1 = on)\n");
-            printf("  -e, --equalizer string\tSets equalizer to specified curve, string must contain band values specific to the device (hex or decimal) delimited by spaces, or commas, or new-lines e.g \"0x18, 0x18, 0x18, 0x18, 0x18\".\n");
+            printf("  -e, --equalizer string\tSets equalizer to specified curve, string must contain band values (hex or decimal), with minimum and maximum values specific to the device and delimited by spaces, or commas, or new-lines e.g \"0, 0, 0, 0, 0\".\n");
             printf("  -p, --equalizer-preset number\tSets equalizer preset, number must be between 0 and 3, 0 sets the default\n");
             printf("      --microphone-mute-led-brightness number\tSets microphone mute LED brightness, number must be between 0 and 3\n");
             printf("      --microphone-volume number\tSets microphone volume, number must be between 0 and 128\n");

--- a/src/utility.c
+++ b/src/utility.c
@@ -79,13 +79,9 @@ size_t hexdump(char* out, size_t out_size, unsigned char* data, size_t data_size
     return i;
 }
 
-int get_data_from_parameter(char* input, char* dest, size_t len)
+int get_byte_data_from_parameter(char* input, unsigned char* dest, size_t len)
 {
     const char* delim = " ,{}\n\r";
-
-    size_t sz = strlen(input);
-    char* str = (char*)malloc(sz + 1);
-    strcpy(str, input);
 
     // For each token in the string, parse and store in buf[].
     char* token = strtok(input, delim);
@@ -101,6 +97,26 @@ int get_data_from_parameter(char* input, char* dest, size_t len)
         token     = strtok(NULL, delim);
     }
 
-    free(str);
+    return i;
+}
+
+int get_float_data_from_parameter(char* input, float* dest, size_t len)
+{
+    const char* delim = " ,{}\n\r";
+
+    // For each token in the string, parse and store in buf[].
+    char* token = strtok(input, delim);
+    int i       = 0;
+    while (token) {
+        char* endptr;
+        float val = strtof(token, &endptr);
+
+        if (i >= len)
+            return -1;
+
+        dest[i++] = val;
+        token     = strtok(NULL, delim);
+    }
+
     return i;
 }

--- a/src/utility.h
+++ b/src/utility.h
@@ -73,4 +73,16 @@ size_t hexdump(char* out, size_t out_size, unsigned char* data, size_t data_size
  * @param len max dest length
  * @return int amount of data converted
  */
-int get_data_from_parameter(char* input, char* dest, size_t len);
+int get_byte_data_from_parameter(char* input, unsigned char* dest, size_t len);
+
+/**
+ * @brief Accepts textual input and converts them to a sendable buffer
+ *
+ * Parses data like "0xff, 123, 0xb" and converts them to an array of len 3
+ *
+ * @param input string
+ * @param dest destination array
+ * @param len max dest length
+ * @return int amount of data converted
+ */
+int get_float_data_from_parameter(char* input, float* dest, size_t len);


### PR DESCRIPTION
Hello! This PR introduces an internal equalizer baseline and band limit. On the one hand, having the baseline means is that, instead of having to input band values specific to the device for the equalizer, e.g.:

``headsetcontrol -e "0x1c 0x19 0x11 0x14 0x14 0x14"``

you can specify the band value shown in the software, e.g.:

``headsetcontrol -e "4 2.5 -1.5 0 0 0"``

Essentially, the baseline is the band value sent in a USB command when it's flat. The band limit, on the other hand, sets limits for those arbitrary values in the equalizer argument string. For example, on the Arctis Nova 3, the minimum and maximum band values are ``-6`` and ``+6`` respectively.

Moreover, this PR fixes potential bugs. For example, the send and send-feature commands used a **signed** byte buffer instead of an unsigned one, which could cause some issues.

Furthermore, the function ``get_data_from_parameter`` in ``utility.c`` (now named ``get_byte_data_from_parameter``) allocated a buffer which was never used, but worse, sometimes was never freed if a certain condition was met. That buffer has been removed.

Finally, I've mentionned support for the Arctis Nova 3 on the README file, something I forgot to do in my last PR. 😅

~~However, this PR has been created as a draft PR due to one issue. The Arctis Nova Pro Wireless is yet another headset that implements the EQ feature, however, I've been unable to find its baseline value. This is because the Equalizer Preset capability for this headset directly sends a value corresponding to an internal preset, unlike the others implementing it which basically send a specific equalizer string directly to the headset.
(cc @Anden: If you can help me figure out the baseline value (perhaps by setting a custom all-flat EQ preset), it would be awesome! Thanks!)~~
EDIT: This has been solved now!