### PR TITLE
JSON-output

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ set(SOURCE_FILES ${SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/device_registry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/hid_utility.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hid_utility.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/output.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/output.h
     ${CMAKE_CURRENT_SOURCE_DIR}/utility.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utility.h
     PARENT_SCOPE)

--- a/src/output.c
+++ b/src/output.c
@@ -1,0 +1,63 @@
+#include "output.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+t_entry* new_entry(char* key, char* value)
+{
+    t_entry* entry = malloc(sizeof(t_entry));
+    entry->key     = strdup(key);
+    entry->value   = strdup(value);
+    return entry;
+}
+
+t_output new_output()
+{
+    t_output output;
+    output.entries = malloc(0);
+    output.length  = 0;
+    return output;
+}
+
+void output_add(t_output* output, t_entry* entry)
+{
+    output->length++;
+    output->entries                     = realloc(output->entries, output->length * sizeof(t_entry));
+    output->entries[output->length - 1] = *entry;
+}
+
+void output_free(t_output* output)
+{
+    free(output->entries);
+    output->length = 0;
+}
+
+char* gen_output(t_output* output)
+{
+    if (output->length == 0) {
+        return strdup("{}");
+    }
+
+    size_t max_length = 2; // For '{' and '}'
+    for (size_t i = 0; i < output->length; i++) {
+        max_length += strlen(output->entries[i].key) + strlen(output->entries[i].value) + 5; // 5 for quotes, colon, and comma
+    }
+
+    char* result = (char*)malloc(max_length + 1); // Allocate memory for the result string
+    if (result == NULL) {
+        // Handle memory allocation failure
+        return NULL;
+    }
+
+    strcpy(result, "{");
+    for (size_t i = 0; i < output->length; i++) {
+        char entry[64];
+        sprintf(entry, "\"%s\":%s,", output->entries[i].key, output->entries[i].value);
+        strcat(result, entry);
+    }
+
+    result[strlen(result) - 1] = '}'; // Replace the last comma with '}'
+    char* dup_result           = strdup(result);
+    free(result);
+    return dup_result;
+}

--- a/src/output.h
+++ b/src/output.h
@@ -1,0 +1,21 @@
+#pragma once
+
+typedef struct {
+    char* key;
+    char* value;
+} t_entry;
+
+t_entry* new_entry(char* key, char* value);
+
+typedef struct {
+    t_entry* entries;
+    int length;
+} t_output;
+
+t_output new_output();
+
+void output_add(t_output* output, t_entry* entry);
+
+void output_free(t_output* output);
+
+char* gen_output(t_output* output);


### PR DESCRIPTION
So apparently this issue for key-value-outputting (#271) exists for some time so I just went and implemented it.
It uses json because it is mostly used in such applications (rather than yaml or similar mentioned in the issue).

The output may look something like this:

```
$ ./headsetcontrol -jb?
{"device":"Logitech G533","battery":74,"capabilities":["sidetone","battery status","inactive time"]}
```

The system is made for allowing many changes in the future (other output values can be added in as little as one line).
For now, a success/error message directly in json is probably redundant because that is mostly managed by the return codes.