### PR TITLE
Rename asprintf to _asprintf to avoid unused-result warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ IF (WIN32)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive")
 ENDIF()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ------------------------------------------------------------------------------

--- a/src/main.c
+++ b/src/main.c
@@ -194,7 +194,7 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
     if ((device_found->capabilities & B(cap)) == 0) {
         result.status = FEATURE_ERROR;
         result.value  = -1;
-        asprintf(&result.message, "This headset doesn't support %s", capabilities_str[cap]);
+        _asprintf(&result.message, "This headset doesn't support %s", capabilities_str[cap]);
         return result;
     }
 
@@ -205,7 +205,7 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         if (!device_handle | !(*device_handle)) {
             result.status = FEATURE_DEVICE_FAILED_OPEN;
             result.value  = 0;
-            asprintf(&result.message, "Could not open device. Error: %ls", hid_error(*device_handle));
+            _asprintf(&result.message, "Could not open device. Error: %ls", hid_error(*device_handle));
             return result;
         }
     } else {
@@ -226,7 +226,7 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         if (battery.status == BATTERY_AVAILABLE) {
             result.status = FEATURE_SUCCESS;
             result.value  = battery.level;
-            asprintf(&result.message, "Battery: %d%%", battery.level);
+            _asprintf(&result.message, "Battery: %d%%", battery.level);
         } else if (battery.status == BATTERY_CHARGING) {
             result.status  = FEATURE_INFO;
             result.value   = battery.level;
@@ -244,9 +244,9 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
             result.value  = (int)battery.status;
 
             if (device_found->idProduct != PRODUCT_TESTDEVICE)
-                asprintf(&result.message, "Error retrieving battery status. Error: %ls", hid_error(*device_handle));
+                _asprintf(&result.message, "Error retrieving battery status. Error: %ls", hid_error(*device_handle));
             else // dont call hid_error on test device
-                asprintf(&result.message, "Error retrieving battery status");
+                _asprintf(&result.message, "Error retrieving battery status");
         }
         return result;
     }
@@ -269,7 +269,7 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         if (ret >= 0) {
             result.status = FEATURE_SUCCESS;
             result.value  = ret;
-            asprintf(&result.message, "Chat-Mix: %d", ret);
+            _asprintf(&result.message, "Chat-Mix: %d", ret);
         } else {
             result.status  = FEATURE_ERROR;
             result.value   = ret;
@@ -324,19 +324,19 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
 
     switch (ret) {
     case HSC_READ_TIMEOUT:
-        asprintf(&result.message, "Failed to set/request %s, because of timeout", capabilities_str[cap]);
+        _asprintf(&result.message, "Failed to set/request %s, because of timeout", capabilities_str[cap]);
         break;
     case HSC_ERROR:
-        asprintf(&result.message, "Failed to set/request %s. HeadsetControl Error", capabilities_str[cap]);
+        _asprintf(&result.message, "Failed to set/request %s. HeadsetControl Error", capabilities_str[cap]);
         break;
     case HSC_OUT_OF_BOUNDS:
-        asprintf(&result.message, "Failed to set/request %s. Provided parameter out of boundaries", capabilities_str[cap]);
+        _asprintf(&result.message, "Failed to set/request %s. Provided parameter out of boundaries", capabilities_str[cap]);
         break;
     default: // Must be a HID error
         if (device_found->idProduct != PRODUCT_TESTDEVICE)
-            asprintf(&result.message, "Failed to set/request %s. Error: %d: %ls", capabilities_str[cap], ret, hid_error(*device_handle));
+            _asprintf(&result.message, "Failed to set/request %s. Error: %d: %ls", capabilities_str[cap], ret, hid_error(*device_handle));
         else // dont call hid_error on test device, it will confuse users/devs because it will show success
-            asprintf(&result.message, "Failed to set/request %s. Error: %d", capabilities_str[cap], ret);
+            _asprintf(&result.message, "Failed to set/request %s. Error: %d", capabilities_str[cap], ret);
 
         break;
     }

--- a/src/output.c
+++ b/src/output.c
@@ -155,8 +155,8 @@ HeadsetControlStatus initializeStatus(int num_devices)
 void initializeHeadsetInfo(HeadsetInfo* info, struct device* device)
 {
     info->status = STATUS_SUCCESS;
-    asprintf(&info->idVendor, "0x%04x", device->idVendor);
-    asprintf(&info->idProduct, "0x%04x", device->idProduct);
+    _asprintf(&info->idVendor, "0x%04x", device->idVendor);
+    _asprintf(&info->idProduct, "0x%04x", device->idProduct);
     info->device_name  = device->device_name;
     info->vendor_name  = device->device_hid_vendorname;
     info->product_name = device->device_hid_productname;

--- a/src/utility.c
+++ b/src/utility.c
@@ -198,7 +198,7 @@ fail:
     return (-1);
 }
 
-int asprintf(char** str, const char* fmt, ...)
+int _asprintf(char** str, const char* fmt, ...)
 {
     va_list ap;
     int ret;

--- a/src/utility.h
+++ b/src/utility.h
@@ -94,4 +94,4 @@ int get_float_data_from_parameter(char* input, float* dest, size_t len);
 
 int vasprintf(char** str, const char* fmt, va_list ap);
 
-int asprintf(char** str, const char* fmt, ...);
+int _asprintf(char** str, const char* fmt, ...);


### PR DESCRIPTION
### Changes made

fixes #335

It would probably be best to actually check the return values for errors on writing. Maybe somethign along these lines:

```c
#define ASSERT_ASPRINTF(x) { if (x < 0) {fprintf(stderr, "Error formatting output"); }
```

### Checklist

- [x] I adjusted the README (if needed)
- [x] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
