### PR TITLE
Fix: Add ID for Arctis Nova 7X revision

### DIFF
--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -12,6 +12,7 @@ static struct device device_arctis;
 
 #define ID_ARCTIS_NOVA_7           0x2202
 #define ID_ARCTIS_NOVA_7x          0x2206
+#define ID_ARCTIS_NOVA_7x_v2       0x2258
 #define ID_ARCTIS_NOVA_7p          0x220a
 #define ID_ARCTIS_NOVA_7_DIABLO_IV 0x223a
 
@@ -26,7 +27,7 @@ static struct device device_arctis;
 #define EQUALIZER_BAND_MIN   -10
 #define EQUALIZER_BAND_MAX   +10
 
-static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV };
+static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7x_v2, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV };
 
 static int arctis_nova_7_send_sidetone(hid_device* device_handle, uint8_t num);
 static int arctis_nova_7_send_inactive_time(hid_device* device_handle, uint8_t num);

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -11,7 +11,7 @@
 static struct device device_arctis;
 
 #define ID_ARCTIS_NOVA_7           0x2202
-#define ID_ARCTIS_NOVA_7x          0x2258
+#define ID_ARCTIS_NOVA_7x          0x2206
 #define ID_ARCTIS_NOVA_7p          0x220a
 #define ID_ARCTIS_NOVA_7_DIABLO_IV 0x223a
 

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -11,7 +11,7 @@
 static struct device device_arctis;
 
 #define ID_ARCTIS_NOVA_7           0x2202
-#define ID_ARCTIS_NOVA_7x          0x2206
+#define ID_ARCTIS_NOVA_7x          0x2258
 #define ID_ARCTIS_NOVA_7p          0x220a
 #define ID_ARCTIS_NOVA_7_DIABLO_IV 0x223a
 


### PR DESCRIPTION
### Changes made

The ID for Arctis Nova 7X seems to be incorrect.



```
❯ headsetcontrol -b
No supported device found

❯ headsetcontrol --dev -- --list --device 0x1038:0x2258
Device Found
  VendorID: 0x1038
 ProductID: 0x2258
  path: /dev/hidraw7
  serial_number: 
  Manufacturer: SteelSeries
  Product:      Arctis Nova 7X
  Interface:    3
  Usage-Page: 0xffc0 Usageid: 0x1

Device Found
  VendorID: 0x1038
 ProductID: 0x2258
  path: /dev/hidraw8
  serial_number: 
  Manufacturer: SteelSeries
  Product:      Arctis Nova 7X
  Interface:    4
  Usage-Page: 0xc Usageid: 0x1

Device Found
  VendorID: 0x1038
 ProductID: 0x2258
  path: /dev/hidraw9
  serial_number: 
  Manufacturer: SteelSeries
  Product:      Arctis Nova 7X
  Interface:    5
  Usage-Page: 0xff00 Usageid: 0x1
```
After changing the ID and recompiling and installing:

```
❯ headsetcontrol -b
Found SteelSeries Arctis Nova 7 (Arctis Nova 7X)!

Battery:
	Status: BATTERY_AVAILABLE
	Level: 100%
```	

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
