### PR TITLE
Added json output of equalizer information of the device

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -93,20 +93,20 @@ typedef struct {
 typedef struct {
     int bands_count;
     int bands_baseline;
+    float bands_step;
     int bands_min;
     int bands_max;
 } EqualizerInfo;
 
 typedef struct {
     char* name;
-    int* values;
+    float* values;
 } EqualizerPreset;
 
 typedef struct {
     int count;
     EqualizerPreset presets[];
 } EqualizerPresets;
-
 
 enum headsetcontrol_errors {
     HSC_ERROR         = -100,
@@ -146,7 +146,7 @@ struct equalizer_settings {
     /// The size of the bands array
     int size;
     /// The equalizer frequency bands values
-    float bands_values[];
+    float* bands_values;
 };
 
 /** @brief Defines the basic data of a device
@@ -166,7 +166,7 @@ struct device {
     /// Name of device, used as information for the user
     char device_name[64];
 
-    //Equalizer Infos
+    // Equalizer Infos
     EqualizerInfo* equalizer;
     EqualizerPresets* eqaulizer_presets;
 

--- a/src/device.h
+++ b/src/device.h
@@ -90,6 +90,24 @@ typedef struct {
     enum microphone_status microphone_status;
 } BatteryInfo;
 
+typedef struct {
+    int bands_count;
+    int bands_baseline;
+    int bands_min;
+    int bands_max;
+} EqualizerInfo;
+
+typedef struct {
+    char* name;
+    int* values;
+} EqualizerPreset;
+
+typedef struct {
+    int count;
+    EqualizerPreset presets[];
+} EqualizerPresets;
+
+
 enum headsetcontrol_errors {
     HSC_ERROR         = -100,
     HSC_READ_TIMEOUT  = -101,
@@ -147,6 +165,10 @@ struct device {
 
     /// Name of device, used as information for the user
     char device_name[64];
+
+    //Equalizer Infos
+    EqualizerInfo* equalizer;
+    EqualizerPresets* eqaulizer_presets;
 
     wchar_t device_hid_vendorname[64];
     wchar_t device_hid_productname[64];

--- a/src/devices/headsetcontrol_test.c
+++ b/src/devices/headsetcontrol_test.c
@@ -16,14 +16,14 @@ static struct device device_headsetcontrol_test;
 #define EQUALIZER_BAND_MAX      +10
 #define EQUALIZER_PRESETS_COUNT 2
 
-static const uint16_t PRODUCT_IDS[]       = { PRODUCT_TESTDEVICE };
-static EqualizerInfo EQUALIZER            = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
-static float flat[EQUALIZER_BANDS_COUNT]    = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-static float random[EQUALIZER_BANDS_COUNT]  = { 6, -8, 1.5, 7, -1, -7.5, -9, 0, 9, 10 };
-static EqualizerPresets EQUALIZER_PRESETS = {
+static const uint16_t PRODUCT_IDS[]        = { PRODUCT_TESTDEVICE };
+static EqualizerInfo EQUALIZER             = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
+static float preset_flat[EQUALIZER_BANDS_COUNT]   = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static float preset_random[EQUALIZER_BANDS_COUNT] = { 6, -8, 1.5, 7, -1, -7.5, -9, 0, 9, 10 };
+static EqualizerPresets EQUALIZER_PRESETS  = {
     EQUALIZER_PRESETS_COUNT,
-    { { "flat", flat },
-        { "random", random } }
+    { { "flat", preset_flat },
+         { "random", preset_random } }
 };
 
 static int headsetcontrol_test_send_sidetone(hid_device* device_handle, uint8_t num);

--- a/src/devices/headsetcontrol_test.c
+++ b/src/devices/headsetcontrol_test.c
@@ -16,14 +16,14 @@ static struct device device_headsetcontrol_test;
 #define EQUALIZER_BAND_MAX      +10
 #define EQUALIZER_PRESETS_COUNT 2
 
-static const uint16_t PRODUCT_IDS[]        = { PRODUCT_TESTDEVICE };
-static EqualizerInfo EQUALIZER             = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
+static const uint16_t PRODUCT_IDS[]               = { PRODUCT_TESTDEVICE };
+static EqualizerInfo EQUALIZER                    = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
 static float preset_flat[EQUALIZER_BANDS_COUNT]   = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 static float preset_random[EQUALIZER_BANDS_COUNT] = { 6, -8, 1.5, 7, -1, -7.5, -9, 0, 9, 10 };
-static EqualizerPresets EQUALIZER_PRESETS  = {
+static EqualizerPresets EQUALIZER_PRESETS         = {
     EQUALIZER_PRESETS_COUNT,
     { { "flat", preset_flat },
-         { "random", preset_random } }
+                { "random", preset_random } }
 };
 
 static int headsetcontrol_test_send_sidetone(hid_device* device_handle, uint8_t num);

--- a/src/devices/headsetcontrol_test.c
+++ b/src/devices/headsetcontrol_test.c
@@ -9,7 +9,23 @@ static struct device device_headsetcontrol_test;
 
 #define TESTBYTES_SEND 32
 
+#define EQUALIZER_BANDS_COUNT      10
+#define EQUALIZER_BASELINE         0
+#define EQUALIZER_BAND_MIN         -10
+#define EQUALIZER_BAND_MAX         +10
+#define EQUALIZER_PRESETS_COUNT    2
+
 static const uint16_t PRODUCT_IDS[] = { PRODUCT_TESTDEVICE };
+static EqualizerInfo EQUALIZER = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX};
+static int flat[EQUALIZER_BANDS_COUNT] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static int random[EQUALIZER_BANDS_COUNT] = { 6, -8, 1, 7, -1, -7, -9, 0, 9, 10 };
+static EqualizerPresets EQUALIZER_PRESETS = {
+    EQUALIZER_PRESETS_COUNT,
+    {
+        { "flat", flat },
+        { "random", random }
+    }
+};
 
 static int headsetcontrol_test_send_sidetone(hid_device* device_handle, uint8_t num);
 static BatteryInfo headsetcontrol_test_request_battery(hid_device* device_handle);
@@ -39,6 +55,8 @@ void headsetcontrol_test_init(struct device** device)
     device_headsetcontrol_test.idVendor            = VENDOR_TESTDEVICE;
     device_headsetcontrol_test.idProductsSupported = PRODUCT_IDS;
     device_headsetcontrol_test.numIdProducts       = 1;
+    device_headsetcontrol_test.equalizer           = &EQUALIZER;
+    device_headsetcontrol_test.eqaulizer_presets   = &EQUALIZER_PRESETS;
 
     strncpy(device_headsetcontrol_test.device_name, "HeadsetControl Test device", sizeof(device_headsetcontrol_test.device_name));
     // normally filled by hid in main.c

--- a/src/devices/headsetcontrol_test.c
+++ b/src/devices/headsetcontrol_test.c
@@ -9,22 +9,21 @@ static struct device device_headsetcontrol_test;
 
 #define TESTBYTES_SEND 32
 
-#define EQUALIZER_BANDS_COUNT      10
-#define EQUALIZER_BASELINE         0
-#define EQUALIZER_BAND_MIN         -10
-#define EQUALIZER_BAND_MAX         +10
-#define EQUALIZER_PRESETS_COUNT    2
+#define EQUALIZER_BANDS_COUNT   10
+#define EQUALIZER_BASELINE      0
+#define EQUALIZER_STEP          0.5
+#define EQUALIZER_BAND_MIN      -10
+#define EQUALIZER_BAND_MAX      +10
+#define EQUALIZER_PRESETS_COUNT 2
 
-static const uint16_t PRODUCT_IDS[] = { PRODUCT_TESTDEVICE };
-static EqualizerInfo EQUALIZER = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX};
-static int flat[EQUALIZER_BANDS_COUNT] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-static int random[EQUALIZER_BANDS_COUNT] = { 6, -8, 1, 7, -1, -7, -9, 0, 9, 10 };
+static const uint16_t PRODUCT_IDS[]       = { PRODUCT_TESTDEVICE };
+static EqualizerInfo EQUALIZER            = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
+static float flat[EQUALIZER_BANDS_COUNT]    = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static float random[EQUALIZER_BANDS_COUNT]  = { 6, -8, 1.5, 7, -1, -7.5, -9, 0, 9, 10 };
 static EqualizerPresets EQUALIZER_PRESETS = {
     EQUALIZER_PRESETS_COUNT,
-    {
-        { "flat", flat },
-        { "random", random }
-    }
+    { { "flat", flat },
+        { "random", random } }
 };
 
 static int headsetcontrol_test_send_sidetone(hid_device* device_handle, uint8_t num);

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -22,12 +22,27 @@ static struct device device_arctis;
 #define HEADSET_OFFLINE 0x00
 #define STATUS_BUF_SIZE 8
 
-#define EQUALIZER_BANDS_SIZE 10
-#define EQUALIZER_BASELINE   0x14
-#define EQUALIZER_BAND_MIN   -10
-#define EQUALIZER_BAND_MAX   +10
+#define EQUALIZER_BANDS_COUNT   10
+#define EQUALIZER_BASELINE      0
+#define EQUALIZER_BAND_MIN      -10
+#define EQUALIZER_BAND_MAX      +10
+#define EQUALIZER_PRESETS_COUNT 2
 
 static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7x_v2, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV };
+
+float flat[MSG_SIZE]   = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+float bass[MSG_SIZE]   = { 3.5, 5.5, 4, 1, -1.5, -1.5, -1, -1, -1, -1 };
+float focus[MSG_SIZE]  = { -5, -3.5, -1, -3.5, -2.5, 4, 6, -3.5, 0 };
+float smiley[MSG_SIZE] = { 3, 3.5, 1.5, -1.5, -4, -4, -2.5, 1.5, 3, 4 };
+
+static EqualizerInfo EQUALIZER            = { EQUALIZER_BANDS_COUNT, 0, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
+static EqualizerPresets EQUALIZER_PRESETS = {
+    EQUALIZER_PRESETS_COUNT,
+    { { "flat", flat },
+        { "bass", bass },
+        { "focus", focus },
+        { "smiley", smiley } }
+};
 
 static int arctis_nova_7_send_sidetone(hid_device* device_handle, uint8_t num);
 static int arctis_nova_7_send_inactive_time(hid_device* device_handle, uint8_t num);
@@ -48,6 +63,8 @@ void arctis_nova_7_init(struct device** device)
     device_arctis.idVendor            = VENDOR_STEELSERIES;
     device_arctis.idProductsSupported = PRODUCT_IDS;
     device_arctis.numIdProducts       = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
+    device_arctis.equalizer           = &EQUALIZER;
+    device_arctis.eqaulizer_presets   = &EQUALIZER_PRESETS;
 
     strncpy(device_arctis.device_name, "SteelSeries Arctis Nova 7", sizeof(device_arctis.device_name));
 
@@ -184,35 +201,46 @@ static int arctis_nova_7_send_equalizer_preset(hid_device* device_handle, uint8_
 {
     // This headset supports only 4 presets:
     // flat (default), bass boost, smiley, focus
+    struct equalizer_settings preset;
+    preset.size = EQUALIZER_BANDS_COUNT;
 
     switch (num) {
     case 0: {
-        uint8_t flat[MSG_SIZE] = { 0x0, 0x33, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x0 };
-        return hid_write(device_handle, flat, MSG_SIZE);
+        preset.bands_values = flat;
+        break;
+        // uint8_t flat[MSG_SIZE] = { 0x0, 0x33, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x14, 0x0 };
+        // return hid_write(device_handle, flat, MSG_SIZE);
     }
     case 1: {
-        uint8_t bass[MSG_SIZE] = { 0x0, 0x33, 0x1b, 0x1f, 0x1c, 0x16, 0x11, 0x11, 0x12, 0x12, 0x12, 0x12, 0x0 };
-        return hid_write(device_handle, bass, MSG_SIZE);
+        preset.bands_values = bass;
+        break;
+        // uint8_t bass[MSG_SIZE] = { 0x0, 0x33, 0x1b, 0x1f, 0x1c, 0x16, 0x11, 0x11, 0x12, 0x12, 0x12, 0x12, 0x0 };
+        // return hid_write(device_handle, bass, MSG_SIZE);
     }
     case 2: {
-        uint8_t smiley[MSG_SIZE] = { 0x0, 0x33, 0x0a, 0x0d, 0x12, 0x0d, 0x0f, 0x1c, 0x20, 0x1b, 0x0d, 0x14, 0x0 };
-        return hid_write(device_handle, smiley, MSG_SIZE);
+        preset.bands_values = focus;
+        break;
+        // uint8_t focus[MSG_SIZE] = { 0x0, 0x33, 0x1a, 0x1b, 0x17, 0x11, 0x0c, 0x0c, 0x0f, 0x17, 0x1a, 0x1c, 0x0 };
+        // return hid_write(device_handle, focus, MSG_SIZE);
     }
     case 3: {
-        uint8_t focus[MSG_SIZE] = { 0x0, 0x33, 0x1a, 0x1b, 0x17, 0x11, 0x0c, 0x0c, 0x0f, 0x17, 0x1a, 0x1c, 0x0 };
-        return hid_write(device_handle, focus, MSG_SIZE);
+        preset.bands_values = smiley;
+        break;
+        // uint8_t smiley[MSG_SIZE] = { 0x0, 0x33, 0x0a, 0x0d, 0x12, 0x0d, 0x0f, 0x1c, 0x20, 0x1b, 0x0d, 0x14, 0x0 };
+        // return hid_write(device_handle, smiley, MSG_SIZE);
     }
     default: {
         printf("Device only supports 0-3 range for presets.\n");
         return HSC_OUT_OF_BOUNDS;
     }
     }
+    return arctis_nova_7_send_equalizer(device_handle, &preset);
 }
 
 static int arctis_nova_7_send_equalizer(hid_device* device_handle, struct equalizer_settings* settings)
 {
-    if (settings->size != EQUALIZER_BANDS_SIZE) {
-        printf("Device only supports %d bands.\n", EQUALIZER_BANDS_SIZE);
+    if (settings->size != EQUALIZER_BANDS_COUNT) {
+        printf("Device only supports %d bands.\n", EQUALIZER_BANDS_COUNT);
         return HSC_OUT_OF_BOUNDS;
     }
 
@@ -224,7 +252,7 @@ static int arctis_nova_7_send_equalizer(hid_device* device_handle, struct equali
             return HSC_OUT_OF_BOUNDS;
         }
 
-        data[i + 2] = (uint8_t)(EQUALIZER_BASELINE + band_value);
+        data[i + 2] = (uint8_t)(0x14 + band_value);
     }
     data[settings->size + 3] = 0x0;
 

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -24,9 +24,10 @@ static struct device device_arctis;
 
 #define EQUALIZER_BANDS_COUNT   10
 #define EQUALIZER_BASELINE      0
+#define EQUALIZER_STEP          0.5
 #define EQUALIZER_BAND_MIN      -10
 #define EQUALIZER_BAND_MAX      +10
-#define EQUALIZER_PRESETS_COUNT 2
+#define EQUALIZER_PRESETS_COUNT 4
 
 static const uint16_t PRODUCT_IDS[] = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7x_v2, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV };
 
@@ -35,7 +36,7 @@ float bass[MSG_SIZE]   = { 3.5, 5.5, 4, 1, -1.5, -1.5, -1, -1, -1, -1 };
 float focus[MSG_SIZE]  = { -5, -3.5, -1, -3.5, -2.5, 4, 6, -3.5, 0 };
 float smiley[MSG_SIZE] = { 3, 3.5, 1.5, -1.5, -4, -4, -2.5, 1.5, 3, 4 };
 
-static EqualizerInfo EQUALIZER            = { EQUALIZER_BANDS_COUNT, 0, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
+static EqualizerInfo EQUALIZER            = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
 static EqualizerPresets EQUALIZER_PRESETS = {
     EQUALIZER_PRESETS_COUNT,
     { { "flat", flat },

--- a/src/main.c
+++ b/src/main.c
@@ -605,8 +605,9 @@ int main(int argc, char* argv[])
                 return 1;
             }
 
-            equalizer       = malloc(sizeof(struct equalizer_settings) + size * sizeof(float));
+            equalizer       = malloc(sizeof(struct equalizer_settings));
             equalizer->size = size;
+            equalizer->bands_values = malloc(sizeof(float) * size);
             for (int i = 0; i < size; i++) {
                 equalizer->bands_values[i] = read_buffer[i];
             }
@@ -950,6 +951,7 @@ int main(int argc, char* argv[])
         free(featureRequests[i].result.message);
     }
 
+    free(equalizer->bands_values);
     free(equalizer);
 
     terminate_hid(&device_handle, &hid_path);

--- a/src/output.c
+++ b/src/output.c
@@ -167,6 +167,11 @@ void initializeHeadsetInfo(HeadsetInfo* info, struct device* device)
     info->vendor_name  = device->device_hid_vendorname;
     info->product_name = device->device_hid_productname;
 
+    info->equalizer = device->equalizer;
+    info->equalizer_presets = device->eqaulizer_presets,
+    info->has_equalizer_info = info->equalizer != NULL;
+    info->has_equalizer_presets_info = info->equalizer_presets != NULL;
+
     info->capabilities_amount = 0;
 
     for (int i = 0; i < NUM_CAPABILITIES; i++) {
@@ -376,6 +381,33 @@ void output_json(HeadsetControlStatus* status, HeadsetInfo* infos)
             printf(",\n");
             printf("        \"level\": %d\n", info->battery_level);
             printf("      }");
+        }
+
+        if (info->has_equalizer_info) {
+            printf(",\n      \"equalizer\": {\n");
+            printf("        \"bands\": %d,\n", info->equalizer->bands_count);
+            printf("        \"baseline\": %d,\n", info->equalizer->bands_baseline);
+            printf("        \"min\": %d,\n", info->equalizer->bands_min);
+            printf("        \"max\": %d\n", info->equalizer->bands_max);
+            printf("      }");
+
+            if (info->has_equalizer_presets_info) {
+                printf(",\n      \"equalizer_presets_count\": %d", info->equalizer_presets->count);
+                printf(",\n      \"equalizer_presets\": {\n");
+                for (int i = 0; i < info->equalizer_presets->count; i++)
+                {
+                    EqualizerPreset* presets = info->equalizer_presets->presets;
+                    printf("        \"%s\": [ ", presets[i].name);
+                    for (int j = 0; j < info->equalizer->bands_count; j++)
+                    {
+                        printf("%d", presets[i].values[j]);
+                        if (j < info->equalizer->bands_count - 1) printf(", ");
+                    }
+                    printf(" ]");
+                    if (i < info->equalizer_presets->count - 1) printf(",\n");
+                }
+                printf("\n      }");
+            }
         }
 
         if (info->has_chatmix_info) {

--- a/src/output.c
+++ b/src/output.c
@@ -395,17 +395,17 @@ void output_json(HeadsetControlStatus* status, HeadsetInfo* infos)
             if (info->has_equalizer_presets_info) {
                 printf(",\n      \"equalizer_presets_count\": %d", info->equalizer_presets->count);
                 printf(",\n      \"equalizer_presets\": {\n");
-                for (int i = 0; i < info->equalizer_presets->count; i++)
-                {
+                for (int i = 0; i < info->equalizer_presets->count; i++) {
                     EqualizerPreset* presets = info->equalizer_presets->presets;
                     printf("        \"%s\": [ ", presets[i].name);
-                    for (int j = 0; j < info->equalizer->bands_count; j++)
-                    {
+                    for (int j = 0; j < info->equalizer->bands_count; j++) {
                         printf("%.1f", presets[i].values[j]);
-                        if (j < info->equalizer->bands_count - 1) printf(", ");
+                        if (j < info->equalizer->bands_count - 1)
+                            printf(", ");
                     }
                     printf(" ]");
-                    if (i < info->equalizer_presets->count - 1) printf(",\n");
+                    if (i < info->equalizer_presets->count - 1)
+                        printf(",\n");
                 }
                 printf("\n      }");
             }

--- a/src/output.c
+++ b/src/output.c
@@ -167,9 +167,9 @@ void initializeHeadsetInfo(HeadsetInfo* info, struct device* device)
     info->vendor_name  = device->device_hid_vendorname;
     info->product_name = device->device_hid_productname;
 
-    info->equalizer = device->equalizer;
-    info->equalizer_presets = device->eqaulizer_presets,
-    info->has_equalizer_info = info->equalizer != NULL;
+    info->equalizer                  = device->equalizer;
+    info->equalizer_presets          = device->eqaulizer_presets,
+    info->has_equalizer_info         = info->equalizer != NULL;
     info->has_equalizer_presets_info = info->equalizer_presets != NULL;
 
     info->capabilities_amount = 0;

--- a/src/output.c
+++ b/src/output.c
@@ -387,6 +387,7 @@ void output_json(HeadsetControlStatus* status, HeadsetInfo* infos)
             printf(",\n      \"equalizer\": {\n");
             printf("        \"bands\": %d,\n", info->equalizer->bands_count);
             printf("        \"baseline\": %d,\n", info->equalizer->bands_baseline);
+            printf("        \"step\": %.1f,\n", info->equalizer->bands_step);
             printf("        \"min\": %d,\n", info->equalizer->bands_min);
             printf("        \"max\": %d\n", info->equalizer->bands_max);
             printf("      }");
@@ -400,7 +401,7 @@ void output_json(HeadsetControlStatus* status, HeadsetInfo* infos)
                     printf("        \"%s\": [ ", presets[i].name);
                     for (int j = 0; j < info->equalizer->bands_count; j++)
                     {
-                        printf("%d", presets[i].values[j]);
+                        printf("%.1f", presets[i].values[j]);
                         if (j < info->equalizer->bands_count - 1) printf(", ");
                     }
                     printf(" ]");

--- a/src/output.h
+++ b/src/output.h
@@ -73,6 +73,11 @@ typedef struct {
     bool has_chatmix_info;
     int chatmix;
 
+    bool has_equalizer_info;
+    EqualizerInfo* equalizer;
+    bool has_equalizer_presets_info;
+    EqualizerPresets* equalizer_presets;
+
     Action actions[MAX_ACTIONS];
     int action_count;
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -105,9 +105,16 @@ int get_byte_data_from_parameter(char* input, unsigned char* dest, size_t len)
 int get_float_data_from_parameter(char* input, float* dest, size_t len)
 {
     const char* delim = " ,{}\n\r";
+    
+    // Make a copy of the input string to avoid modifying the original
+    char* input_copy = strdup(input);
+    if (input_copy == NULL) {
+        // Memory allocation failed
+        return -1;
+    }
 
-    // For each token in the string, parse and store in buf[].
-    char* token = strtok(input, delim);
+    // For each token in the string, parse and store in dest[].
+    char* token = strtok(input_copy, delim);
     int i       = 0;
     while (token) {
         char* endptr;


### PR DESCRIPTION
### Changes made

- `EqualizerInfo` and `EqualizerPreset` and `EqualizerPresets` structs
- Added `EqualizerInfo` and `EqualizerPreset` and `EqualizerPresets` structs to `device` struct
- Added `json `output for `EqualizerPreset` and `EqualizerPresets`
- Refactor of `steelseries_arctis_nova_7.c` for adding support of the new info to output

### Checklist

- [ ] I adjusted the README (if needed)
- [x] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
