### PR TITLE
Add Arctis Nova 5 EQ Presets and Equalizer settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 | ROCCAT Elo 7.1 Air |   |   |   | x | x |   |   |   |   |   |   |   |   |   |   |
 | ROCCAT Elo 7.1 USB |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis Nova 3 | x |   |   |   |   |   |   |   | x | x | x | x |   |   |   |
-| SteelSeries Arctis Nova 5 | x | x |   |   | x |   |   |   |   |   | x | x | x |   |   |
+| SteelSeries Arctis Nova 5 | x | x |   |   | x |   |   |   | x | x | x | x | x |   |   |
 | SteelSeries Arctis Nova 7 | x | x |   |   | x | x |   |   | x | x | x | x | x | x | x |
 | SteelSeries Arctis 7+ | x | x |   |   | x | x |   |   | x | x |   |   |   |   |   |
 | SteelSeries Arctis Nova Pro Wireless | x | x |   | x | x |   |   |   | x | x |   |   |   |   |   |


### PR DESCRIPTION
### Changes made
Added respective capability and implement setting the well known SteelSeries EQ presets and EQ Settings

I figured out the format by toying around with a self made capture cotaining all the profiles supported by SteelSeries GG  and trying decoding them and comparing with the values provided by the UI: https://gitlab.com/hrzlgnm/steelseries-gg-profiles

### Checklist

- [x] I adjusted the README (if needed)
- [x] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
