### PR TITLE
Added --repeat option for --dev arguments

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -134,7 +134,10 @@ static void print_help()
            "\t--timeout in millisecounds for --receive\n");
     printf("  --receive-feature REPORTID\n"
            "\tTry to receive a report for REPORTID.\n");
+    printf("  --repeat SECS\n"
+           "\tRepeat command every SECS.\n");
     printf("\n");
+    
 
     printf("  --dev-help\n"
            "\tThis menu\n");
@@ -163,12 +166,14 @@ int dev_main(int argc, char* argv[])
     int send         = 0;
     int send_feature = 0;
 
-    int sleep = -1;
+    int sleep_time = -1;
 
     int receive       = 0;
     int receivereport = 0;
 
     int timeout = -1;
+
+    int repeat_seconds = 0;
 
     int print_deviceinfo = 0;
 
@@ -191,6 +196,7 @@ int dev_main(int argc, char* argv[])
         { "receive-feature", required_argument, NULL, 'g' },
         { "timeout", required_argument, NULL, 't' },
         { "dev-help", no_argument, NULL, 'h' },
+        { "repeat", required_argument, NULL, 0 },
         { 0, 0, 0, 0 }
     };
 
@@ -274,9 +280,9 @@ int dev_main(int argc, char* argv[])
             break;
         }
         case 'm': { // --sleep
-            sleep = strtol(optarg, NULL, 10);
+            sleep_time = strtol(optarg, NULL, 10);
 
-            if (sleep < 0) {
+            if (sleep_time < 0) {
                 fprintf(stderr, "--sleep must be positive\n");
                 return 1;
             }
@@ -307,6 +313,17 @@ int dev_main(int argc, char* argv[])
             if (timeout < -1) {
                 fprintf(stderr, "--timeout cannot be smaller than -1\n");
                 return 1;
+            }
+            break;
+        }
+        case 0: {
+            if (strcmp(opts[option_index].name, "repeat") == 0) { // --repeat SECS
+                repeat_seconds = strtol(optarg, NULL, 10);
+
+                if (repeat_seconds < 1) {
+                    fprintf(stderr, "--repeat SECS cannot be smaller than 1\n");
+                    return 1;
+                }
             }
             break;
         }
@@ -361,63 +378,66 @@ int dev_main(int argc, char* argv[])
         return 1;
     }
 
-    if (send) {
-        int ret = hid_write(device_handle, (const unsigned char*)sendbuffer, send);
+    do{
+        if (send) {
+            int ret = hid_write(device_handle, (const unsigned char*)sendbuffer, send);
 
-        if (ret < 0) {
-            fprintf(stderr, "Failed to send data. Error: %d: %ls\n", ret, hid_error(device_handle));
-            terminate_hid(&device_handle, &hid_path);
-            return 1;
-        }
-    }
-
-    if (send_feature) {
-        int ret = hid_send_feature_report(device_handle, (const unsigned char*)sendreportbuffer, send_feature);
-
-        if (ret < 0) {
-            fprintf(stderr, "Failed to send data. Error: %d: %ls\n", ret, hid_error(device_handle));
-            terminate_hid(&device_handle, &hid_path);
-            return 1;
-        }
-    }
-
-    if (sleep >= 0) { // also allow 0 as a minimum sleep
-        usleep(sleep * 1000);
-    }
-
-    if (receive) {
-        int read = hid_read_timeout(device_handle, receivebuffer, BUFFERLENGTH, timeout);
-
-        if (read < 0) {
-            fprintf(stderr, "Failed to read. Error: %d: %ls\n", read, hid_error(device_handle));
-            terminate_hid(&device_handle, &hid_path);
-            return 1;
-        } else if (read == 0) {
-            fprintf(stderr, "No data to read\n");
-        } else {
-            for (int i = 0; i < read; i++) {
-                printf("%#04x ", receivebuffer[i]);
+            if (ret < 0) {
+                fprintf(stderr, "Failed to send data. Error: %d: %ls\n", ret, hid_error(device_handle));
+                terminate_hid(&device_handle, &hid_path);
+                return 1;
             }
-            printf("\n");
         }
-    }
 
-    if (receivereport) {
-        int read = hid_get_feature_report(device_handle, receivereportbuffer, BUFFERLENGTH);
+        if (send_feature) {
+            int ret = hid_send_feature_report(device_handle, (const unsigned char*)sendreportbuffer, send_feature);
 
-        if (read < 0) {
-            fprintf(stderr, "Failed to read. Error: %d: %ls\n", read, hid_error(device_handle));
-            terminate_hid(&device_handle, &hid_path);
-            return 1;
-        } else if (read == 0) {
-            fprintf(stderr, "No data to read\n");
-        } else {
-            for (int i = 0; i < read; i++) {
-                printf("%#04x ", receivereportbuffer[i]);
+            if (ret < 0) {
+                fprintf(stderr, "Failed to send data. Error: %d: %ls\n", ret, hid_error(device_handle));
+                terminate_hid(&device_handle, &hid_path);
+                return 1;
             }
-            printf("\n");
         }
-    }
+
+        if (sleep_time >= 0) { // also allow 0 as a minimum sleep
+            usleep(sleep_time * 1000);
+        }
+
+        if (receive) {
+            int read = hid_read_timeout(device_handle, receivebuffer, BUFFERLENGTH, timeout);
+
+            if (read < 0) {
+                fprintf(stderr, "Failed to read. Error: %d: %ls\n", read, hid_error(device_handle));
+                terminate_hid(&device_handle, &hid_path);
+                return 1;
+            } else if (read == 0) {
+                fprintf(stderr, "No data to read\n");
+            } else {
+                for (int i = 0; i < read; i++) {
+                    printf("%#04x ", receivebuffer[i]);
+                }
+                printf("\n");
+            }
+        }
+
+        if (receivereport) {
+            int read = hid_get_feature_report(device_handle, receivereportbuffer, BUFFERLENGTH);
+
+            if (read < 0) {
+                fprintf(stderr, "Failed to read. Error: %d: %ls\n", read, hid_error(device_handle));
+                terminate_hid(&device_handle, &hid_path);
+                return 1;
+            } else if (read == 0) {
+                fprintf(stderr, "No data to read\n");
+            } else {
+                for (int i = 0; i < read; i++) {
+                    printf("%#04x ", receivereportbuffer[i]);
+                }
+                printf("\n");
+            }
+        }
+        sleep(repeat_seconds);
+    }while(repeat_seconds);
 
     terminate_hid(&device_handle, &hid_path);
 

--- a/src/dev.c
+++ b/src/dev.c
@@ -137,7 +137,6 @@ static void print_help()
     printf("  --repeat SECS\n"
            "\tRepeat command every SECS.\n");
     printf("\n");
-    
 
     printf("  --dev-help\n"
            "\tThis menu\n");
@@ -378,7 +377,7 @@ int dev_main(int argc, char* argv[])
         return 1;
     }
 
-    do{
+    do {
         if (send) {
             int ret = hid_write(device_handle, (const unsigned char*)sendbuffer, send);
 
@@ -437,7 +436,7 @@ int dev_main(int argc, char* argv[])
             }
         }
         sleep(repeat_seconds);
-    }while(repeat_seconds);
+    } while (repeat_seconds);
 
     terminate_hid(&device_handle, &hid_path);
 

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -161,16 +161,10 @@ static BatteryInfo arctis_nova_7_request_battery(hid_device* device_handle)
 
     int bat = data_read[2];
 
-    if (bat >= BATTERY_MAX)
+    if (bat > BATTERY_MAX)
         info.level = 100;
-    else if (bat == 0x3)
-        info.level = 50;
-    else if (bat == 0x2)
-        info.level = 15;
-    else if (bat == 0x1)
-        info.level = 5;
     else
-        info.level = 0;
+        info.level = map(bat, BATTERY_MIN, BATTERY_MAX, 0, 100);
 
     return info;
 }


### PR DESCRIPTION
### Changes made

Added --repeat option for --dev arguments.

Example of usage:
`headsetcontrol --dev -- --device 0x1038:0x2202  --interface 3 --send 0x00,0xb0 --receive --repeat 5`

It essentially repeats command evey 5 seconds (sleep between one to another can be changed and should be > 1)

It will be useful to users that are not familiar with wireshark or other programs to track changing bytes for features like battery, chatmix, etc..

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
