### PR TITLE
Add new G733 hardware ID

### DIFF
--- a/src/devices/logitech_g633_g933_935.c
+++ b/src/devices/logitech_g633_g933_935.c
@@ -15,8 +15,9 @@ static struct device device_g933_935;
 #define ID_LOGITECH_G935   0x0a87
 #define ID_LOGITECH_G733   0x0ab5
 #define ID_LOGITECH_G733_2 0x0afe
+#define ID_LOGITECH_G733_3 0x0b1f
 
-static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733, ID_LOGITECH_G733_2 };
+static const uint16_t PRODUCT_IDS[] = { ID_LOGITECH_G633, ID_LOGITECH_G635, ID_LOGITECH_G933, ID_LOGITECH_G935, ID_LOGITECH_G733, ID_LOGITECH_G733_2, ID_LOGITECH_G733_3 };
 
 static int g933_935_send_sidetone(hid_device* device_handle, uint8_t num);
 static BatteryInfo g933_935_request_battery(hid_device* device_handle);


### PR DESCRIPTION
### Changes made

I just picked up a G733 and I couldn't originally manage it with HeadsetControl. I found out it actually has a different hardware ID than other versions of the G733 did! So I added it to ID array, and it works now.

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
