### PR TITLE
Fix build workflow: update zip command to include all matching artifacts

### DIFF
--- a/.github/workflows/continuos-release.yml
+++ b/.github/workflows/continuos-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Zip build artifacts
         run: |
           cd build
-          zip -r headsetcontrol-${{ matrix.os_name }}-${{ matrix.architecture }}.zip headsetcontrol
+          zip -r headsetcontrol-${{ matrix.os_name }}-${{ matrix.architecture }}.zip headsetcontrol*
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Changes made

Atm the `windows.zip` file of the `continuous` build contains a file without `.exe` extension.
That fixes the CI

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
