### PR TITLE
Add openSUSE prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Before building, ensure you have the necessary dependencies installed, including
 
 RHEL and CentOS also require the epel-repository.
 
-`yum install epel-release`
-`yum groupinstall "Development tools"`
+`yum install epel-release`  
+`yum groupinstall "Development tools"`  
 `yum install git cmake hidapi-devel`
 
 #### Fedora
@@ -69,7 +69,7 @@ RHEL and CentOS also require the epel-repository.
 
 #### openSUSE
 
-`zypper in -t pattern devel_basis`
+`zypper in -t pattern devel_basis`  
 `zypper in cmake libhidapi-devel`
 
 #### Sabayon

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ RHEL and CentOS also require the epel-repository.
 
 `dnf install cmake hidapi-devel g++`
 
+#### openSUSE
+
+`zypper in -t pattern devel_basis`
+`zypper in cmake libhidapi-devel`
+
 #### Sabayon
 
 `equo i hidapi cmake`


### PR DESCRIPTION
### Changes made

Updated `README.md` to include prerequisites for building on openSUSE.

### Checklist

- [X] I adjusted the README (if needed)
- [X] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
