### PR TITLE
Add parametric equalizer and implement it for Arctis Nova 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,33 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 
 ## Supported Headsets
 
-| Device | sidetone | battery | notification sound | lights | inactive time | chatmix | voice prompts | rotate to mute | equalizer preset | equalizer | microphone mute led brightness | microphone volume | volume limiter | bluetooth when powered on | bluetooth call volume |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Corsair Headset Device | x | x | x | x |   |   |   |   |   |   |   |   |   |   |   |
-| HyperX Cloud Alpha Wireless | x | x |   |   | x |   | x |   |   |   |   |   |   |   |   |
-| HyperX Cloud Flight Wireless |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| HyperX Cloud 3 | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Logitech G430 | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Logitech G432/G433 | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Logitech G533 | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |
-| Logitech G535 | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |
-| Logitech G930 | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Logitech G633/G635/G733/G933/G935 | x | x |   | x |   |   |   |   |   |   |   |   |   |   |   |
-| Logitech G PRO Series | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |
-| Logitech G PRO X 2 | x |   |   |   | x |   |   |   |   |   |   |   |   |   |   |
-| Logitech Zone Wired/Zone 750 | x |   |   |   |   |   | x | x |   |   |   |   |   |   |   |
-| SteelSeries Arctis (1/7X/7P) Wireless | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |
-| SteelSeries Arctis (7/Pro) | x | x |   | x | x | x |   |   |   |   |   |   |   |   |   |
-| SteelSeries Arctis 9 | x | x |   |   | x | x |   |   |   |   |   |   |   |   |   |
-| SteelSeries Arctis Pro Wireless | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |
-| ROCCAT Elo 7.1 Air |   |   |   | x | x |   |   |   |   |   |   |   |   |   |   |
-| ROCCAT Elo 7.1 USB |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
-| SteelSeries Arctis Nova 3 | x |   |   |   |   |   |   |   | x | x | x | x |   |   |   |
-| SteelSeries Arctis Nova (5/5X) | x | x |   |   | x | x |   |   | x | x | x | x | x |   |   |
-| SteelSeries Arctis Nova 7 | x | x |   |   | x | x |   |   | x | x | x | x | x | x | x |
-| SteelSeries Arctis 7+ | x | x |   |   | x | x |   |   | x | x |   |   |   |   |   |
-| SteelSeries Arctis Nova Pro Wireless | x | x |   | x | x |   |   |   | x | x |   |   |   |   |   |
-| HeadsetControl Test device | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| Device | sidetone | battery | notification sound | lights | inactive time | chatmix | voice prompts | rotate to mute | equalizer preset | equalizer | parametric equalizer | microphone mute led brightness | microphone volume | volume limiter | bluetooth when powered on | bluetooth call volume |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Corsair Headset Device | x | x | x | x |   |   |   |   |   |   |   |   |   |   |   |   |
+| HyperX Cloud Alpha Wireless | x | x |   |   | x |   | x |   |   |   |   |   |   |   |   |   |
+| HyperX Cloud Flight Wireless |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| HyperX Cloud 3 | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G430 | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G432/G433 | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G533 | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G535 | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G930 | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G633/G635/G733/G933/G935 | x | x |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G PRO Series | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G PRO X 2 | x |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech Zone Wired/Zone 750 | x |   |   |   |   |   | x | x |   |   |   |   |   |   |   |   |
+| SteelSeries Arctis (1/7X/7P) Wireless | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| SteelSeries Arctis (7/Pro) | x | x |   | x | x | x |   |   |   |   |   |   |   |   |   |   |
+| SteelSeries Arctis 9 | x | x |   |   | x | x |   |   |   |   |   |   |   |   |   |   |
+| SteelSeries Arctis Pro Wireless | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| ROCCAT Elo 7.1 Air |   |   |   | x | x |   |   |   |   |   |   |   |   |   |   |   |
+| ROCCAT Elo 7.1 USB |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
+| SteelSeries Arctis Nova 3 | x |   |   |   |   |   |   |   | x | x |   | x | x |   |   |   |
+| SteelSeries Arctis Nova (5/5X) | x | x |   |   | x | x |   |   | x | x | x | x | x | x |   |   |
+| SteelSeries Arctis Nova 7 | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |
+| SteelSeries Arctis 7+ | x | x |   |   | x | x |   |   | x | x |   |   |   |   |   |   |
+| SteelSeries Arctis Nova Pro Wireless | x | x |   | x | x |   |   |   | x | x |   |   |   |   |   |   |
+| HeadsetControl Test device | x | x | x | x | x | x | x | x | x | x |   | x | x | x | x | x |
 
 For non-supported headsets on Linux: There is a chance that you can set the sidetone via AlsaMixer
 

--- a/src/device.c
+++ b/src/device.c
@@ -12,6 +12,7 @@ const char* const capabilities_str[NUM_CAPABILITIES]
           [CAP_ROTATE_TO_MUTE]                 = "rotate to mute",
           [CAP_EQUALIZER_PRESET]               = "equalizer preset",
           [CAP_EQUALIZER]                      = "equalizer",
+          [CAP_PARAMETRIC_EQUALIZER]           = "parametric equalizer",
           [CAP_MICROPHONE_MUTE_LED_BRIGHTNESS] = "microphone mute led brightness",
           [CAP_MICROPHONE_VOLUME]              = "microphone volume",
           [CAP_VOLUME_LIMITER]                 = "volume limiter",
@@ -31,6 +32,7 @@ const char* const capabilities_str_enum[NUM_CAPABILITIES]
           [CAP_ROTATE_TO_MUTE]                 = "CAP_ROTATE_TO_MUTE",
           [CAP_EQUALIZER_PRESET]               = "CAP_EQUALIZER_PRESET",
           [CAP_EQUALIZER]                      = "CAP_EQUALIZER",
+          [CAP_PARAMETRIC_EQUALIZER]           = "CAP_PARAMETRIC_EQUALIZER",
           [CAP_MICROPHONE_MUTE_LED_BRIGHTNESS] = "CAP_MICROPHONE_MUTE_LED_BRIGHTNESS",
           [CAP_MICROPHONE_VOLUME]              = "CAP_MICROPHONE_VOLUME",
           [CAP_VOLUME_LIMITER]                 = "CAP_VOLUME_LIMITER",
@@ -50,10 +52,21 @@ const char capabilities_str_short[NUM_CAPABILITIES]
           [CAP_ROTATE_TO_MUTE]                 = 'r',
           [CAP_EQUALIZER_PRESET]               = 'p',
           [CAP_EQUALIZER]                      = 'e',
+          [CAP_PARAMETRIC_EQUALIZER]           = 'q',
           [CAP_MICROPHONE_MUTE_LED_BRIGHTNESS] = 't',
           [CAP_MICROPHONE_VOLUME]              = 'o',
           // new capabilities since short output was deprecated
           [CAP_VOLUME_LIMITER]     = '\0',
           [CAP_BT_WHEN_POWERED_ON] = '\0',
           [CAP_BT_CALL_VOLUME]     = '\0'
+      };
+
+const char* const equalizer_filter_type_str[NUM_EQ_FILTER_TYPES]
+    = {
+          [EQ_FILTER_LOWSHELF]  = "lowshelf",
+          [EQ_FILTER_LOWPASS]   = "lowpass",
+          [EQ_FILTER_PEAKING]   = "peaking",
+          [EQ_FILTER_HIGHPASS]  = "highpass",
+          [EQ_FILTER_HIGHSHELF] = "highshelf"
+
       };

--- a/src/device.h
+++ b/src/device.h
@@ -34,6 +34,7 @@ enum capabilities {
     CAP_ROTATE_TO_MUTE,
     CAP_EQUALIZER_PRESET,
     CAP_EQUALIZER,
+    CAP_PARAMETRIC_EQUALIZER,
     CAP_MICROPHONE_MUTE_LED_BRIGHTNESS,
     CAP_MICROPHONE_VOLUME,
     CAP_VOLUME_LIMITER,
@@ -104,6 +105,19 @@ typedef struct {
 } EqualizerPreset;
 
 typedef struct {
+    int bands_count;
+    float gain_base; // default/base gain
+    float gain_step;
+    float gain_min;
+    float gain_max;
+    float q_factor_min; // q factor
+    float q_factor_max;
+    int freq_min; // frequency
+    int freq_max;
+    int filter_types; // bitmap containing available filter types
+} ParametricEqualizerInfo;
+
+typedef struct {
     int count;
     EqualizerPreset presets[];
 } EqualizerPresets;
@@ -112,6 +126,7 @@ enum headsetcontrol_errors {
     HSC_ERROR         = -100,
     HSC_READ_TIMEOUT  = -101,
     HSC_OUT_OF_BOUNDS = -102,
+    HSC_INVALID_ARG   = -103,
 };
 
 typedef enum {
@@ -140,13 +155,43 @@ typedef struct {
     FeatureResult result;
 } FeatureRequest;
 
-/** @brief Defines equalizer custom setings
+/** @brief Defines equalizer custom settings
  */
 struct equalizer_settings {
     /// The size of the bands array
     int size;
     /// The equalizer frequency bands values
     float* bands_values;
+};
+
+typedef enum {
+    EQ_FILTER_LOWSHELF,
+    EQ_FILTER_LOWPASS,
+    EQ_FILTER_PEAKING,
+    EQ_FILTER_HIGHPASS,
+    EQ_FILTER_HIGHSHELF,
+    NUM_EQ_FILTER_TYPES
+} EqualizerFilterType;
+
+/// Enum name of every parametric equalizer filter type
+extern const char* const equalizer_filter_type_str[NUM_EQ_FILTER_TYPES];
+
+/** @brief Defines parametric equalizer custom settings
+ */
+struct parametric_equalizer_settings {
+    /// The size of the bands array
+    int size;
+    /// The equalizer bands
+    struct parametric_equalizer_band* bands;
+};
+
+/** @brief Defines parameteric equalizer band
+ */
+struct parametric_equalizer_band {
+    float frequency;
+    float gain;
+    float q_factor;
+    EqualizerFilterType type;
 };
 
 /** @brief Defines the basic data of a device
@@ -168,7 +213,8 @@ struct device {
 
     // Equalizer Infos
     EqualizerInfo* equalizer;
-    EqualizerPresets* eqaulizer_presets;
+    EqualizerPresets* equalizer_presets;
+    ParametricEqualizerInfo* parametric_equalizer;
 
     wchar_t device_hid_vendorname[64];
     wchar_t device_hid_productname[64];
@@ -317,6 +363,24 @@ struct device {
      *              -1                 HIDAPI error
      */
     int (*send_equalizer)(hid_device* hid_device, struct equalizer_settings* settings);
+
+    /** @brief Function pointer for setting headset parametric equalizer
+     *
+     *  Forwards the request to the device specific implementation
+     *
+     *  @param  device_handle   The hidapi handle. Must be the same
+     *                          device as defined here (same ids)
+     *  @param  settings        The parametric equalizer settings containing
+     *                          the filter values
+     *
+     *  @returns    > 0                on success
+     *              HSC_OUT_OF_BOUNDS  on equalizer settings size out of range
+     *                                 specific to this hardware
+     *              HSC_INVALID_ARG    on equalizer filter type invalid/unsupported
+     *                                 specific to this hardware
+     *              -1                 HIDAPI error
+     */
+    int (*send_parametric_equalizer)(hid_device* hid_device, struct parametric_equalizer_settings* settings);
 
     /** @brief Function pointer for setting headset microphone mute LED brightness
      *

--- a/src/devices/headsetcontrol_test.c
+++ b/src/devices/headsetcontrol_test.c
@@ -16,6 +16,17 @@ static struct device device_headsetcontrol_test;
 #define EQUALIZER_BAND_MAX      +10
 #define EQUALIZER_PRESETS_COUNT 2
 
+// parametric equalizer
+#define EQUALIZER_GAIN_BASE    20
+#define EQUALIZER_GAIN_STEP    0.5
+#define EQUALIZER_GAIN_MIN     -10
+#define EQUALIZER_GAIN_MAX     10
+#define EQUALIZER_Q_FACTOR_MIN 0.2
+#define EQUALIZER_Q_FACTOR_MAX 10.0
+#define EQUALIZER_FREQ_MIN     20
+#define EQUALIZER_FREQ_MAX     20000
+#define EQUALIZER_FILTERS      (B(EQ_FILTER_LOWSHELF) | B(EQ_FILTER_LOWPASS) | B(EQ_FILTER_PEAKING) | B(EQ_FILTER_HIGHPASS) | B(EQ_FILTER_HIGHSHELF))
+
 static const uint16_t PRODUCT_IDS[]               = { PRODUCT_TESTDEVICE };
 static EqualizerInfo EQUALIZER                    = { EQUALIZER_BANDS_COUNT, EQUALIZER_BASELINE, EQUALIZER_STEP, EQUALIZER_BAND_MIN, EQUALIZER_BAND_MAX };
 static float preset_flat[EQUALIZER_BANDS_COUNT]   = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -24,6 +35,10 @@ static EqualizerPresets EQUALIZER_PRESETS         = {
     EQUALIZER_PRESETS_COUNT,
     { { "flat", preset_flat },
                 { "random", preset_random } }
+};
+static ParametricEqualizerInfo PARAMETRIC_EQUALIZER = {
+    EQUALIZER_BANDS_COUNT, EQUALIZER_GAIN_BASE, EQUALIZER_GAIN_STEP, EQUALIZER_GAIN_MIN, EQUALIZER_GAIN_MAX,
+    EQUALIZER_Q_FACTOR_MIN, EQUALIZER_Q_FACTOR_MAX, EQUALIZER_FREQ_MIN, EQUALIZER_FREQ_MAX, EQUALIZER_FILTERS
 };
 
 static int headsetcontrol_test_send_sidetone(hid_device* device_handle, uint8_t num);
@@ -52,11 +67,12 @@ void headsetcontrol_test_init(struct device** device)
         abort();
     }
 
-    device_headsetcontrol_test.idVendor            = VENDOR_TESTDEVICE;
-    device_headsetcontrol_test.idProductsSupported = PRODUCT_IDS;
-    device_headsetcontrol_test.numIdProducts       = 1;
-    device_headsetcontrol_test.equalizer           = &EQUALIZER;
-    device_headsetcontrol_test.equalizer_presets   = &EQUALIZER_PRESETS;
+    device_headsetcontrol_test.idVendor             = VENDOR_TESTDEVICE;
+    device_headsetcontrol_test.idProductsSupported  = PRODUCT_IDS;
+    device_headsetcontrol_test.numIdProducts        = 1;
+    device_headsetcontrol_test.equalizer            = &EQUALIZER;
+    device_headsetcontrol_test.equalizer_presets    = &EQUALIZER_PRESETS;
+    device_headsetcontrol_test.parametric_equalizer = &PARAMETRIC_EQUALIZER;
 
     strncpy(device_headsetcontrol_test.device_name, "HeadsetControl Test device", sizeof(device_headsetcontrol_test.device_name));
     // normally filled by hid in main.c

--- a/src/devices/headsetcontrol_test.c
+++ b/src/devices/headsetcontrol_test.c
@@ -32,6 +32,7 @@ static int headsetcontrol_test_notification_sound(hid_device* device_handle, uin
 static int headsetcontrol_test_lights(hid_device* device_handle, uint8_t on);
 static int headsetcontrol_test_send_equalizer_preset(hid_device* device_handle, uint8_t num);
 static int headsetcontrol_test_send_equalizer(hid_device* device_handle, struct equalizer_settings* settings);
+static int headsetcontrol_test_send_parametric_equalizer(hid_device* device_handle, struct parametric_equalizer_settings* settings);
 static int headsetcontrol_test_send_microphone_mute_led_brightness(hid_device* device_handle, uint8_t num);
 static int headsetcontrol_test_send_microphone_volume(hid_device* device_handle, uint8_t num);
 static int headsetcontrol_test_switch_voice_prompts(hid_device* device_handle, uint8_t on);
@@ -55,7 +56,7 @@ void headsetcontrol_test_init(struct device** device)
     device_headsetcontrol_test.idProductsSupported = PRODUCT_IDS;
     device_headsetcontrol_test.numIdProducts       = 1;
     device_headsetcontrol_test.equalizer           = &EQUALIZER;
-    device_headsetcontrol_test.eqaulizer_presets   = &EQUALIZER_PRESETS;
+    device_headsetcontrol_test.equalizer_presets   = &EQUALIZER_PRESETS;
 
     strncpy(device_headsetcontrol_test.device_name, "HeadsetControl Test device", sizeof(device_headsetcontrol_test.device_name));
     // normally filled by hid in main.c
@@ -63,7 +64,7 @@ void headsetcontrol_test_init(struct device** device)
     wcsncpy(device_headsetcontrol_test.device_hid_productname, L"Test device", sizeof(device_headsetcontrol_test.device_hid_productname) / sizeof(device_headsetcontrol_test.device_hid_productname[0]));
 
     if (test_profile != 10) {
-        device_headsetcontrol_test.capabilities = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_NOTIFICATION_SOUND) | B(CAP_LIGHTS) | B(CAP_INACTIVE_TIME) | B(CAP_CHATMIX_STATUS) | B(CAP_VOICE_PROMPTS) | B(CAP_ROTATE_TO_MUTE) | B(CAP_EQUALIZER_PRESET) | B(CAP_EQUALIZER) | B(CAP_MICROPHONE_MUTE_LED_BRIGHTNESS) | B(CAP_MICROPHONE_VOLUME) | B(CAP_VOLUME_LIMITER) | B(CAP_BT_WHEN_POWERED_ON) | B(CAP_BT_CALL_VOLUME);
+        device_headsetcontrol_test.capabilities = B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_NOTIFICATION_SOUND) | B(CAP_LIGHTS) | B(CAP_INACTIVE_TIME) | B(CAP_CHATMIX_STATUS) | B(CAP_VOICE_PROMPTS) | B(CAP_ROTATE_TO_MUTE) | B(CAP_EQUALIZER_PRESET) | B(CAP_EQUALIZER) | B(CAP_PARAMETRIC_EQUALIZER) | B(CAP_MICROPHONE_MUTE_LED_BRIGHTNESS) | B(CAP_MICROPHONE_VOLUME) | B(CAP_VOLUME_LIMITER) | B(CAP_BT_WHEN_POWERED_ON) | B(CAP_BT_CALL_VOLUME);
     } else {
         device_headsetcontrol_test.capabilities = B(CAP_SIDETONE) | B(CAP_LIGHTS) | B(CAP_BATTERY_STATUS);
     }
@@ -78,6 +79,7 @@ void headsetcontrol_test_init(struct device** device)
     device_headsetcontrol_test.switch_rotate_to_mute               = &headsetcontrol_test_switch_rotate_to_mute;
     device_headsetcontrol_test.send_equalizer_preset               = &headsetcontrol_test_send_equalizer_preset;
     device_headsetcontrol_test.send_equalizer                      = &headsetcontrol_test_send_equalizer;
+    device_headsetcontrol_test.send_parametric_equalizer           = &headsetcontrol_test_send_parametric_equalizer;
     device_headsetcontrol_test.send_microphone_mute_led_brightness = &headsetcontrol_test_send_microphone_mute_led_brightness;
     device_headsetcontrol_test.send_microphone_volume              = &headsetcontrol_test_send_microphone_volume;
     device_headsetcontrol_test.send_volume_limiter                 = &headsetcontrol_test_volume_limiter;
@@ -143,6 +145,11 @@ static int headsetcontrol_test_send_equalizer_preset(hid_device* device_handle, 
 }
 
 static int headsetcontrol_test_send_equalizer(hid_device* device_handle, struct equalizer_settings* settings)
+{
+    return TESTBYTES_SEND;
+}
+
+static int headsetcontrol_test_send_parametric_equalizer(hid_device* device_handle, struct parametric_equalizer_settings* settings)
 {
     return TESTBYTES_SEND;
 }

--- a/src/devices/steelseries_arctis_nova_5.c
+++ b/src/devices/steelseries_arctis_nova_5.c
@@ -452,7 +452,7 @@ static int nova_5_write_device_band(struct parametric_equalizer_band* filter, ui
             return HSC_OUT_OF_BOUNDS;
         }
     }
-    if (!has_capability(EQUALIZER_FILTERS, filter->type)) {
+    if (!has_capability(EQUALIZER_FILTERS, (int)filter->type)) {
         printf("Unsupported filter type.\n");
         return HSC_ERROR;
     }

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -66,7 +66,7 @@ void arctis_nova_7_init(struct device** device)
     device_arctis.idProductsSupported = PRODUCT_IDS;
     device_arctis.numIdProducts       = sizeof(PRODUCT_IDS) / sizeof(PRODUCT_IDS[0]);
     device_arctis.equalizer           = &EQUALIZER;
-    device_arctis.eqaulizer_presets   = &EQUALIZER_PRESETS;
+    device_arctis.equalizer_presets   = &EQUALIZER_PRESETS;
 
     strncpy(device_arctis.device_name, "SteelSeries Arctis Nova 7", sizeof(device_arctis.device_name));
 

--- a/src/main.c
+++ b/src/main.c
@@ -294,6 +294,10 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         ret = device_found->send_equalizer(*device_handle, (struct equalizer_settings*)param);
         break;
 
+    case CAP_PARAMETRIC_EQUALIZER:
+        ret = device_found->send_parametric_equalizer(*device_handle, (struct parametric_equalizer_settings*)param);
+        break;
+
     case CAP_MICROPHONE_MUTE_LED_BRIGHTNESS:
         ret = device_found->send_microphone_mute_led_brightness(*device_handle, (uint8_t) * (int*)param);
         break;
@@ -343,6 +347,9 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         break;
     case HSC_OUT_OF_BOUNDS:
         _asprintf(&result.message, "Failed to set/request %s. Provided parameter out of boundaries", capabilities_str[cap]);
+        break;
+    case HSC_INVALID_ARG:
+        _asprintf(&result.message, "Failed to set/request %s. Provided parameter invalid", capabilities_str[cap]);
         break;
     default: // Must be a HID error
         if (device_found->idProduct != PRODUCT_TESTDEVICE)
@@ -418,8 +425,9 @@ void print_help(char* programname, struct device* device_found, bool _show_all)
     // ------
 
     // ------ Category: Equalizer
-    bool show_equalizer        = show_all || has_capability(device_found->capabilities, CAP_EQUALIZER);
-    bool show_equalizer_preset = show_all || has_capability(device_found->capabilities, CAP_EQUALIZER_PRESET);
+    bool show_equalizer            = show_all || has_capability(device_found->capabilities, CAP_EQUALIZER);
+    bool show_equalizer_preset     = show_all || has_capability(device_found->capabilities, CAP_EQUALIZER_PRESET);
+    bool show_parametric_equalizer = show_all || has_capability(device_found->capabilities, CAP_PARAMETRIC_EQUALIZER);
 
     if (show_equalizer || show_equalizer_preset) {
         printf("Equalizer:\n");
@@ -429,6 +437,26 @@ void print_help(char* programname, struct device* device_found, bool _show_all)
         if (show_equalizer_preset) {
             printf("  -p, --equalizer-preset NUMBER\tSet equalizer preset (0-3, 0 for default)\n");
         }
+        printf("\n");
+    }
+
+    if (show_parametric_equalizer) {
+        // TODO parametric equalizer
+        printf("Parametric Equalizer:\n");
+        printf("  --parametric-equalizer STRING\t\tSet equalizer bands (bands separated by semicolon)\n");
+        printf("      Band format:\t\t\tFREQUENCY,GAIN,Q_FACTOR,FILTER_TYPE\n");
+        printf("      Availabe filter types:\t\t");
+        for (int i = 0; i < NUM_EQ_FILTER_TYPES; i++) {
+            if (show_all || has_capability(device_found->parametric_equalizer->filter_types, i)) {
+                printf("%s, ", equalizer_filter_type_str[i]);
+            }
+        }
+        printf("\n\n");
+        printf("      Examples:\t--parametric-equalizer\t'300,3.5,1.5,peaking;14000,-2,1.414,highshelf'\n");
+        printf("      \t\t\t\t\tSets a 300Hz +3.5dB Q1.5 peaking filter\n\t\t\t\t\tand a 14kHz -2dB Q1.414 highshelf filter\n");
+        printf("\n");
+        printf("      \t\t--parametric-equalizer\treset\n");
+        printf("      \t\t\t\t\tResets/disables all bands");
         printf("\n");
     }
     // ------
@@ -521,28 +549,29 @@ int main(int argc, char* argv[])
 {
     int c;
 
-    int should_print_help                = 0;
-    int should_print_help_all            = 0;
-    int print_udev_rules                 = 0;
-    int sidetone_loudness                = -1;
-    int request_battery                  = 0;
-    int request_chatmix                  = 0;
-    int request_connected                = 0;
-    int notification_sound               = -1;
-    int lights                           = -1;
-    int inactive_time                    = -1;
-    int voice_prompts                    = -1;
-    int rotate_to_mute                   = -1;
-    int print_capabilities               = -1;
-    int equalizer_preset                 = -1;
-    int microphone_mute_led_brightness   = -1;
-    int microphone_volume                = -1;
-    int volume_limiter                   = -1;
-    int bt_when_powered_on               = -1;
-    int bt_call_volume                   = -1;
-    int dev_mode                         = 0;
-    unsigned follow_sec                  = 2;
-    struct equalizer_settings* equalizer = NULL;
+    int should_print_help                                      = 0;
+    int should_print_help_all                                  = 0;
+    int print_udev_rules                                       = 0;
+    int sidetone_loudness                                      = -1;
+    int request_battery                                        = 0;
+    int request_chatmix                                        = 0;
+    int request_connected                                      = 0;
+    int notification_sound                                     = -1;
+    int lights                                                 = -1;
+    int inactive_time                                          = -1;
+    int voice_prompts                                          = -1;
+    int rotate_to_mute                                         = -1;
+    int print_capabilities                                     = -1;
+    int equalizer_preset                                       = -1;
+    int microphone_mute_led_brightness                         = -1;
+    int microphone_volume                                      = -1;
+    int volume_limiter                                         = -1;
+    int bt_when_powered_on                                     = -1;
+    int bt_call_volume                                         = -1;
+    int dev_mode                                               = 0;
+    unsigned follow_sec                                        = 2;
+    struct equalizer_settings* equalizer                       = NULL;
+    struct parametric_equalizer_settings* parametric_equalizer = NULL;
 
     OutputType output_format = OUTPUT_STANDARD;
     int test_device          = 0;
@@ -562,6 +591,7 @@ int main(int argc, char* argv[])
         { "help-all", no_argument, NULL, 0 },
         { "equalizer", required_argument, NULL, 'e' },
         { "equalizer-preset", required_argument, NULL, 'p' },
+        { "parametric-equalizer", required_argument, NULL, 0 },
         { "microphone-mute-led-brightness", required_argument, NULL, 0 },
         { "microphone-volume", required_argument, NULL, 0 },
         { "inactive-time", required_argument, NULL, 'i' },
@@ -788,6 +818,16 @@ int main(int argc, char* argv[])
                     }
                 }
                 // fall through
+            } else if (strcmp(opts[option_index].name, "parametric-equalizer") == 0) {
+                parametric_equalizer = parse_parametric_equalizer_settings(optarg);
+
+                for (int i = 0; i < parametric_equalizer->size; i++) {
+                    if ((int)parametric_equalizer->bands[i].type == HSC_INVALID_ARG) {
+                        fprintf(stderr, "Unknown filter type specified to --parametric-equalizer\n");
+                        return 1;
+                    }
+                }
+                // fall through
             } else if (strcmp(opts[option_index].name, "readme-helper") == 0) {
                 // We need to initialize it at this point
                 init_devices();
@@ -868,6 +908,7 @@ int main(int argc, char* argv[])
         { CAP_MICROPHONE_MUTE_LED_BRIGHTNESS, CAPABILITYTYPE_ACTION, &microphone_mute_led_brightness, microphone_mute_led_brightness != -1, {} },
         { CAP_MICROPHONE_VOLUME, CAPABILITYTYPE_ACTION, &microphone_volume, microphone_volume != -1, {} },
         { CAP_EQUALIZER, CAPABILITYTYPE_ACTION, equalizer, equalizer != NULL, {} },
+        { CAP_PARAMETRIC_EQUALIZER, CAPABILITYTYPE_ACTION, parametric_equalizer, parametric_equalizer != NULL, {} },
         { CAP_VOLUME_LIMITER, CAPABILITYTYPE_ACTION, &volume_limiter, volume_limiter != -1, {} },
         { CAP_BT_WHEN_POWERED_ON, CAPABILITYTYPE_ACTION, &bt_when_powered_on, bt_when_powered_on != -1, {} },
         { CAP_BT_CALL_VOLUME, CAPABILITYTYPE_ACTION, &bt_call_volume, bt_call_volume != -1, {} }
@@ -953,8 +994,13 @@ int main(int argc, char* argv[])
 
     if (equalizer != NULL) {
         free(equalizer->bands_values);
+        free(equalizer);
     }
-    free(equalizer);
+
+    if (parametric_equalizer != NULL) {
+        free(parametric_equalizer->bands);
+        free(parametric_equalizer);
+    }
 
     terminate_hid(&device_handle, &hid_path);
     return 0;

--- a/src/output.c
+++ b/src/output.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-const char* APIVERSION          = "1.2";
+const char* APIVERSION          = "1.3";
 const char* HEADSETCONTROL_NAME = "HeadsetControl";
 
 // Function to convert enum to string
@@ -418,26 +418,31 @@ void output_json(HeadsetControlStatus* status, HeadsetInfo* infos)
             printf(",\n      \"parametric_equalizer\": {\n");
             printf("        \"bands\": %d,\n", info->parametric_equalizer->bands_count);
             printf("        \"gain\": {\n");
-            printf("            \"step\": %g,\n", info->parametric_equalizer->gain_step);
-            printf("            \"min\": %g,\n", info->parametric_equalizer->gain_min);
-            printf("            \"max\": %g,\n", info->parametric_equalizer->gain_max);
-            printf("            \"base\": %g\n", info->parametric_equalizer->gain_base);
+            printf("          \"step\": %g,\n", info->parametric_equalizer->gain_step);
+            printf("          \"min\": %g,\n", info->parametric_equalizer->gain_min);
+            printf("          \"max\": %g,\n", info->parametric_equalizer->gain_max);
+            printf("          \"base\": %g\n", info->parametric_equalizer->gain_base);
             printf("        },\n");
             printf("        \"q_factor\": {\n");
-            printf("            \"min\": %g,\n", info->parametric_equalizer->q_factor_min);
-            printf("            \"max\": %g\n", info->parametric_equalizer->q_factor_max);
+            printf("          \"min\": %g,\n", info->parametric_equalizer->q_factor_min);
+            printf("          \"max\": %g\n", info->parametric_equalizer->q_factor_max);
             printf("        },\n");
             printf("        \"frequency\": {\n");
-            printf("            \"min\": %d,\n", info->parametric_equalizer->freq_min);
-            printf("            \"max\": %d\n", info->parametric_equalizer->freq_max);
+            printf("          \"min\": %d,\n", info->parametric_equalizer->freq_min);
+            printf("          \"max\": %d\n", info->parametric_equalizer->freq_max);
             printf("        },\n");
-            printf("        \"filter_types:\" [\n");
+            printf("        \"filter_types\": [\n");
+            int first = true;
             for (int i = 0; i < NUM_EQ_FILTER_TYPES; i++) {
                 if (has_capability(info->parametric_equalizer->filter_types, i)) {
-                    printf("            \"%s\",\n", equalizer_filter_type_str[i]);
+                    if (!first) { // print first without a leading comma
+                        printf(",\n");
+                    }
+                    printf("          \"%s\"", equalizer_filter_type_str[i]);
+                    first = 0;
                 }
             }
-            printf("        ]\n");
+            printf("\n        ]\n");
             printf("      }");
         }
 

--- a/src/output.c
+++ b/src/output.c
@@ -168,9 +168,12 @@ void initializeHeadsetInfo(HeadsetInfo* info, struct device* device)
     info->product_name = device->device_hid_productname;
 
     info->equalizer                  = device->equalizer;
-    info->equalizer_presets          = device->eqaulizer_presets,
+    info->equalizer_presets          = device->equalizer_presets,
     info->has_equalizer_info         = info->equalizer != NULL;
     info->has_equalizer_presets_info = info->equalizer_presets != NULL;
+
+    info->parametric_equalizer          = device->parametric_equalizer,
+    info->has_parametric_equalizer_info = info->parametric_equalizer != NULL;
 
     info->capabilities_amount = 0;
 
@@ -411,6 +414,33 @@ void output_json(HeadsetControlStatus* status, HeadsetInfo* infos)
             }
         }
 
+        if (info->has_parametric_equalizer_info) {
+            printf(",\n      \"parametric_equalizer\": {\n");
+            printf("        \"bands\": %d,\n", info->parametric_equalizer->bands_count);
+            printf("        \"gain\": {\n");
+            printf("            \"step\": %g,\n", info->parametric_equalizer->gain_step);
+            printf("            \"min\": %g,\n", info->parametric_equalizer->gain_min);
+            printf("            \"max\": %g,\n", info->parametric_equalizer->gain_max);
+            printf("            \"base\": %g\n", info->parametric_equalizer->gain_base);
+            printf("        },\n");
+            printf("        \"q_factor\": {\n");
+            printf("            \"min\": %g,\n", info->parametric_equalizer->q_factor_min);
+            printf("            \"max\": %g\n", info->parametric_equalizer->q_factor_max);
+            printf("        },\n");
+            printf("        \"frequency\": {\n");
+            printf("            \"min\": %d,\n", info->parametric_equalizer->freq_min);
+            printf("            \"max\": %d\n", info->parametric_equalizer->freq_max);
+            printf("        },\n");
+            printf("        \"filter_types:\" [\n");
+            for (int i = 0; i < NUM_EQ_FILTER_TYPES; i++) {
+                if (has_capability(info->parametric_equalizer->filter_types, i)) {
+                    printf("            \"%s\",\n", equalizer_filter_type_str[i]);
+                }
+            }
+            printf("        ]\n");
+            printf("      }");
+        }
+
         if (info->has_chatmix_info) {
             printf(",\n      \"chatmix\": %d", info->chatmix);
         }
@@ -464,6 +494,14 @@ void yaml_printint(const char* key, const int value, int indent)
         putchar(' ');
     }
     printf("%s: %d\n", yaml_replace_spaces_with_dash(key), value);
+}
+
+void yaml_printfloat(const char* key, const float value, int indent)
+{
+    for (int i = 0; i < indent; i++) {
+        putchar(' ');
+    }
+    printf("%s: %g\n", yaml_replace_spaces_with_dash(key), value);
 }
 
 const char* yaml_replace_spaces_with_dash(const char* str)
@@ -596,6 +634,28 @@ void output_yaml(HeadsetControlStatus* status, HeadsetInfo* infos)
                         yaml_print_listitemfloat(presets[i].values[j], 8, false);
                     }
                     putchar('\n');
+                }
+            }
+        }
+
+        if (info->has_parametric_equalizer_info) {
+            yaml_print("parametric_equalizer", "", 4);
+            yaml_printint("bands", info->parametric_equalizer->bands_count, 6);
+            yaml_print("gain", "", 6);
+            yaml_printfloat("step", info->parametric_equalizer->gain_step, 8);
+            yaml_printfloat("min", info->parametric_equalizer->gain_min, 8);
+            yaml_printfloat("max", info->parametric_equalizer->gain_max, 8);
+            yaml_printfloat("base", info->parametric_equalizer->gain_base, 8);
+            yaml_print("q_factor", "", 6);
+            yaml_printfloat("min", info->parametric_equalizer->q_factor_min, 8);
+            yaml_printfloat("max", info->parametric_equalizer->q_factor_max, 8);
+            yaml_print("frequency", "", 6);
+            yaml_printint("min", info->parametric_equalizer->freq_min, 8);
+            yaml_printint("max", info->parametric_equalizer->freq_max, 8);
+            yaml_print("filter_types", "", 6);
+            for (int i = 0; i < NUM_EQ_FILTER_TYPES; i++) {
+                if (has_capability(info->parametric_equalizer->filter_types, i)) {
+                    yaml_print_listitem(equalizer_filter_type_str[i], 8, true);
                 }
             }
         }

--- a/src/output.h
+++ b/src/output.h
@@ -77,6 +77,8 @@ typedef struct {
     EqualizerInfo* equalizer;
     bool has_equalizer_presets_info;
     EqualizerPresets* equalizer_presets;
+    bool has_parametric_equalizer_info;
+    ParametricEqualizerInfo* parametric_equalizer;
 
     Action actions[MAX_ACTIONS];
     int action_count;

--- a/src/utility.c
+++ b/src/utility.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "device.h"
 #include "utility.h"
 
 int map(int x, int in_min, int in_max, int out_min, int out_max)
@@ -135,6 +136,136 @@ int get_float_data_from_parameter(char* input, float* dest, size_t len)
     }
 
     return i;
+}
+
+/**
+ * Converts a filter type string to the corresponding EqualizerFilterType enum
+ * Returns HSC_INVALID_ARG if the string does not match a known filter type.
+ */
+static EqualizerFilterType parse_eq_filter_type(const char* input)
+{
+    for (int i = 0; i < NUM_EQ_FILTER_TYPES; i++) {
+        if (strcmp(input, equalizer_filter_type_str[i]) == 0) {
+            return i;
+        }
+    }
+
+    return HSC_INVALID_ARG;
+}
+
+/**
+ * Parses a equalizer band string into a struct parametric_equalizer_band.
+ *
+ * Expected band_str format: "float,float,float,string"
+ * Expected fields:          "frequency,gain,q-factor,filter-type"
+ *
+ * Returns HSC_INVALID_ARG if the string can't be parsed.
+ */
+static int parse_parametric_equalizer_band(const char* band_str, struct parametric_equalizer_band* out_band)
+{
+    const char* delim = " ,";
+
+    // Make a modifiable copy of input, because strtok modifies the string.
+    char* tmp = strdup(band_str);
+    if (!tmp) {
+        return -1;
+    }
+
+    // parse freq, gain, q_factor, type
+    char* token = strtok(tmp, delim);
+    if (!token) {
+        free(tmp);
+        return HSC_INVALID_ARG;
+    }
+    out_band->frequency = strtof(token, NULL);
+
+    token = strtok(NULL, delim);
+    if (!token) {
+        free(tmp);
+        return HSC_INVALID_ARG;
+    }
+    out_band->gain = strtof(token, NULL);
+
+    token = strtok(NULL, delim);
+    if (!token) {
+        free(tmp);
+        return HSC_INVALID_ARG;
+    }
+    out_band->q_factor = strtof(token, NULL);
+
+    token = strtok(NULL, delim);
+    if (!token) {
+        free(tmp);
+        return HSC_INVALID_ARG;
+    }
+
+    out_band->type = parse_eq_filter_type(token);
+    if ((int)out_band->type == HSC_INVALID_ARG) {
+        printf("Couldn't parse filter type: %s\n", token);
+        free(tmp);
+        return HSC_INVALID_ARG;
+    }
+
+    free(tmp);
+    return 0;
+}
+
+/**
+ * Parses the full parametric equalizer string that can contain multiple band
+ * definitions separated by ';' into a parametric_equalizer_settings object.
+ *
+ * Example of input format:
+ *     "100.0,3.5,1.0,lowshelf;500.0,-2.0,1.2,peaking;2000.0,5.0,0.7,highshelf"
+ */
+struct parametric_equalizer_settings* parse_parametric_equalizer_settings(const char* input)
+{
+    struct parametric_equalizer_settings* settings = malloc(sizeof(struct parametric_equalizer_settings));
+    settings->size                                 = 0;
+    settings->bands                                = NULL;
+
+    if (!input || !*input || (strcmp(input, "reset") == 0)) {
+        // Return empty if null/empty or reset of bands requested.
+        // The device implementation is responsible for resetting
+        // all remaining bands that are not provided by the user (all in this case).
+        return settings;
+    }
+
+    // create a modifiable copy of the input
+    char* input_copy = strdup(input);
+    if (!input_copy) {
+        return settings;
+    }
+
+    // Count how many bands we have by counting the number of semicolons + 1
+    int band_count = 1;
+    for (const char* p = input; *p; ++p) {
+        if (*p == ';') {
+            band_count++;
+        }
+    }
+
+    // Allocate space for bands
+    struct parametric_equalizer_band* bands = (struct parametric_equalizer_band*)calloc(band_count, sizeof(struct parametric_equalizer_band));
+
+    if (!bands) {
+        free(input_copy);
+        return settings;
+    }
+
+    // Tokenize by ';' and parse each band definition
+    char* context  = NULL;
+    char* band_str = strtok_r(input_copy, ";", &context);
+    int i          = 0;
+    while (band_str && i < band_count) {
+        parse_parametric_equalizer_band(band_str, &bands[i++]);
+        band_str = strtok_r(NULL, ";", &context);
+    }
+
+    settings->size  = i;
+    settings->bands = bands;
+
+    free(input_copy);
+    return settings;
 }
 
 // ----------------- asprintf / vasprintf -----------------

--- a/src/utility.h
+++ b/src/utility.h
@@ -92,6 +92,8 @@ int get_byte_data_from_parameter(char* input, unsigned char* dest, size_t len);
  */
 int get_float_data_from_parameter(char* input, float* dest, size_t len);
 
+struct parametric_equalizer_settings* parse_parametric_equalizer_settings(const char* input);
+
 int vasprintf(char** str, const char* fmt, va_list ap);
 
 int _asprintf(char** str, const char* fmt, ...);


### PR DESCRIPTION
### Changes made
Added support for parametric equalizers.
Added implementation for Arctis Nova 5.

### Description

I did not want to break the existing basic equalizer implementation so I added it independently as
- capability CAP_PARAMETRIC_EQUALIZER
- struct ParametricEqualizerInfo
- struct parametric_equalizer_settings
- struct parametric_equalizer_band
- enum EqualizerFilterType

I added YAML and JSON outputs, help texts, output of capabilities and the five filter types the Arctis Nova 5 supports for now.
More filter types can be added if other headsets feature different filters and the supported filters are set by each devices implementation.

I implemented the 10 band parametric equalizer for the Arctis Nova 5 and tested setting bands and the different filter types against the SteelSeries GG Windows software.

Bands are represented by the typical parameters of parametric equalizers: frequency, gain, q-factor (band width) and filter type.

This is the help text (which also gives an example of the format I chose to specify the bands):

```
Parametric Equalizer:
  --parametric-equalizer STRING         Set equalizer bands (bands separated by semicolon)
      Band format:                      FREQUENCY,GAIN,Q_FACTOR,FILTER_TYPE
      Availabe filter types:            lowshelf, lowpass, peaking, highpass, highshelf, 

      Examples: --parametric-equalizer  '300,3.5,1.5,peaking;14000,-2,1.414,highshelf'
                                        Sets a 300Hz +3.5dB Q1.5 peaking filter
                                        and a 14kHz -2dB Q1.414 highshelf filter

                --parametric-equalizer  reset
                                        Resets/disables all bands
```

This is the info the JSON (and YAML) output contains:
```json
      "parametric_equalizer": {
        "bands": 10,
        "gain": {
            "step": 0.5,
            "min": -10,
            "max": 10,
            "base": 20
        },
        "q_factor": {
            "min": 0.2,
            "max": 10
        },
        "frequency": {
            "min": 20,
            "max": 20000
        },
        "filter_types": [
            "lowshelf",
            "lowpass",
            "peaking",
            "highpass",
            "highshelf",
        ]
      },
```

### Headset Name

Arctis Nova 5

### Checklist

- [X] I adjusted the README (if needed)
- [X] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
