### PR TITLE
Upgrade clang-format to version 18 and improve version consistency

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,4 +12,4 @@ jobs:
       with:
         source: '.'
         extensions: 'h,c'
-        clangFormatVersion: 16
+        clangFormatVersion: 18

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,10 +96,24 @@ endif()
 
 if(ENABLE_CLANG_FORMAT)
 
-    find_program(CLANG_FORMAT_BIN clang-format)
+    # Try to find clang-format-18 first to match CI version
+    find_program(CLANG_FORMAT_BIN
+        NAMES clang-format-18 clang-format
+        PATHS /opt/homebrew/opt/llvm@18/bin /usr/local/opt/llvm@18/bin
+    )
 
     if(CLANG_FORMAT_BIN STREQUAL "CLANG_FORMAT_BIN-NOTFOUND")
-        message(FATAL_ERROR "unable to locate clang-format")
+        message(FATAL_ERROR "unable to locate clang-format (try: brew install llvm@18)")
+    endif()
+
+    # Warn if not using version 18
+    execute_process(
+        COMMAND ${CLANG_FORMAT_BIN} --version
+        OUTPUT_VARIABLE CLANG_FORMAT_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT CLANG_FORMAT_VERSION MATCHES "version 18")
+        message(WARNING "Using ${CLANG_FORMAT_VERSION}, but CI uses version 18. Install llvm@18 for consistency.")
     endif()
 
     file(GLOB_RECURSE ALL_SOURCE_FILES *.c *.cpp *.h *.cxx *.hxx *.hpp *.cc *.ipp)

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Helper script to format code with the correct clang-format version
+# This ensures consistency with CI
+
+set -e
+
+# Try to find clang-format-18
+CLANG_FORMAT=""
+
+if command -v clang-format-18 &> /dev/null; then
+    CLANG_FORMAT="clang-format-18"
+elif [ -f "/opt/homebrew/opt/llvm@18/bin/clang-format" ]; then
+    CLANG_FORMAT="/opt/homebrew/opt/llvm@18/bin/clang-format"
+elif [ -f "/usr/local/opt/llvm@18/bin/clang-format" ]; then
+    CLANG_FORMAT="/usr/local/opt/llvm@18/bin/clang-format"
+else
+    echo "Error: clang-format-18 not found!"
+    echo "Please install it:"
+    echo "  macOS: brew install llvm@18"
+    echo "  Linux: sudo apt-get install clang-format-18"
+    exit 1
+fi
+
+# Check version
+VERSION=$($CLANG_FORMAT --version)
+echo "Using: $VERSION"
+
+if [[ ! "$VERSION" =~ "version 18" ]]; then
+    echo "Warning: Not using version 18! CI uses version 18."
+    read -p "Continue anyway? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Format all C and H files
+echo "Formatting code..."
+find src -name "*.c" -o -name "*.h" | xargs $CLANG_FORMAT -i
+
+echo "Done! All source files formatted."

--- a/src/main.c
+++ b/src/main.c
@@ -291,7 +291,7 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
 
     switch (cap) {
     case CAP_SIDETONE:
-        ret = device_found->send_sidetone(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_sidetone(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_BATTERY_STATUS: {
@@ -327,15 +327,15 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
     }
 
     case CAP_NOTIFICATION_SOUND:
-        ret = device_found->notification_sound(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->notification_sound(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_LIGHTS:
-        ret = device_found->switch_lights(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->switch_lights(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_INACTIVE_TIME:
-        ret = device_found->send_inactive_time(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_inactive_time(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_CHATMIX_STATUS:
@@ -354,11 +354,11 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         return result;
 
     case CAP_VOICE_PROMPTS:
-        ret = device_found->switch_voice_prompts(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->switch_voice_prompts(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_ROTATE_TO_MUTE:
-        ret = device_found->switch_rotate_to_mute(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->switch_rotate_to_mute(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_EQUALIZER_PRESET: {
@@ -386,23 +386,23 @@ static FeatureResult handle_feature(struct device* device_found, hid_device** de
         break;
 
     case CAP_MICROPHONE_MUTE_LED_BRIGHTNESS:
-        ret = device_found->send_microphone_mute_led_brightness(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_microphone_mute_led_brightness(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_MICROPHONE_VOLUME:
-        ret = device_found->send_microphone_volume(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_microphone_volume(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_VOLUME_LIMITER:
-        ret = device_found->send_volume_limiter(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_volume_limiter(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_BT_WHEN_POWERED_ON:
-        ret = device_found->send_bluetooth_when_powered_on(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_bluetooth_when_powered_on(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case CAP_BT_CALL_VOLUME:
-        ret = device_found->send_bluetooth_call_volume(*device_handle, (uint8_t)*(int*)param);
+        ret = device_found->send_bluetooth_call_volume(*device_handle, (uint8_t) * (int*)param);
         break;
 
     case NUM_CAPABILITIES:


### PR DESCRIPTION
Fixes the formatting version mismatch between local development and CI that was causing formatting conflicts in PRs.

Changes:
- Update CI to use clang-format version 18 (was 16)
- Update CMakeLists.txt to prefer clang-format-18
- Add version detection with warnings if using different version
- Add format-code.sh helper script for easy local formatting
- Reformat code with version 18 (spacing improvements around casts)
