### PR TITLE
docs: Add headset-battery-indicator GUI link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ The following additional software can be used to enable control via a GUI
 
 [gnome-shell-extension-HeadsetControl](https://github.com/ChrisLauinger77/gnome-shell-extension-HeadsetControl/) adds a system tray icon, displaying headset information. Also provides controls via the icon's menu (gnome-shell 42 and later)
 
+[headset-battery-indicator](https://github.com/ruflas/headset-battery-indicator) adds a system tray icon for managing USB headset features, including battery level, ChatMix, Sidetone, and Auto-Off time. (Python/Qt based)
+
 #### Windows
 
 [HeadsetControl-GUI](https://github.com/LeoKlaus/HeadsetControl-GUI)  a simply GUI tool to manage your headset and check battery status. (Qt C++ based)


### PR DESCRIPTION
### Changes made

<!--- Describe your changes here --->.
Adds a new entry under the "Linux" section in the README.md to list `headset-battery-indicator`, a Python/Qt system tray application. This application serves as a graphical frontend for HeadsetControl, providing features like battery level, ChatMix, Sidetone, and Auto-Off time.
This change was made following the suggestion from Denis via email.
### Checklist

- [x] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
