### PR TITLE
Add aarol/headset-battery-indicator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ The following additional software can be used to enable control via a GUI
 
 [HeadsetControl-Qt](https://github.com/Odizinne/HeadsetControl-Qt) adds a system tray icon, GUI with various settings, Linux compatible. (Qt C++ based)
 
+[aarol/headset-battery-indicator](https://github.com/aarol/headset-battery-indicator) adds a small native-looking system tray icon displaying the battery level. (Rust based)
+
 ## Development
 
 Look at the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development) if you want to contribute and implement another device or improve the software.


### PR DESCRIPTION
### Changes made

I recently stopped trying to reinvent the wheel and rewrote my Rust-based headset indicator program to use HeadsetControl. 

The project is unfortunately named exactly the same as ruflas' `headset-battery-indicator`, so I called mine `aarol/headset-battery-indicator`.

### Checklist

- [x] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
