### PR TITLE
Add suport for SteelSeries Arctis Nova 3X Wireless

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 | ROCCAT Elo 7.1 Air | All |   |   |   | x | x |   |   |   |   |   |   |   |   |   |   |   |
 | ROCCAT Elo 7.1 USB | All |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis Nova 3 | All | x |   |   |   |   |   |   |   | x | x |   | x | x |   |   |   |
-| SteelSeries Arctis Nova 3P Wireless | L/M | x | x |   |   | x |   |   |   | x | x | x |   | x |   |   |   |
+| SteelSeries Arctis Nova 3P/3X Wireless | L/M | x | x |   |   | x |   |   |   | x | x | x |   | x |   |   |   |
 | SteelSeries Arctis Nova (5/5X) | All | x | x |   |   | x | x |   |   | x | x | x | x | x | x |   |   |
 | SteelSeries Arctis Nova 7 | All | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |
 | SteelSeries Arctis Nova 7 Wireless Gen 2 | All | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |

--- a/src/devices/steelseries_arctis_nova_3p_wireless.c
+++ b/src/devices/steelseries_arctis_nova_3p_wireless.c
@@ -8,6 +8,7 @@
 #define MSG_SIZE 64
 
 #define ID_ARCTIS_NOVA_3P_WIRELESS 0x2269
+#define ID_ARCTIS_NOVA_3X_WIRELESS 0x226d
 
 #define HEADSET_ONLINE  0x03
 #define HEADSET_OFFLINE 0x02
@@ -70,7 +71,7 @@ static uint8_t EQUALIZER_FILTER_MAP[NUM_EQ_FILTER_TYPES] = {
 
 static struct device device_arctis;
 
-static const uint16_t PRODUCT_IDS[]      = { ID_ARCTIS_NOVA_3P_WIRELESS };
+static const uint16_t PRODUCT_IDS[]      = { ID_ARCTIS_NOVA_3P_WIRELESS, ID_ARCTIS_NOVA_3X_WIRELESS };
 static const uint8_t SAVE_DATA[MSG_SIZE] = { 0x09 };
 
 static int arctis_nova_3p_wireless_send_sidetone(hid_device* device_handle, uint8_t num);


### PR DESCRIPTION
### Changes made

Suport for SteelSeries Arctis Nova 3X Wireless (deviceId 0x226d) added based on the 3P support.

### Checklist

- [X] I adjusted the README (if needed)