### PR TITLE
add support for SteelSeries Arctis Nova 7x Wireless Gen 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ talking. This differs from a simple loopback via PulseAudio as you won't have an
 | SteelSeries Arctis Nova 3P/3X Wireless | L/M | x | x |   |   | x |   |   |   | x | x | x |   | x |   |   |   |
 | SteelSeries Arctis Nova (5/5X) | All | x | x |   |   | x | x |   |   | x | x | x | x | x | x |   |   |
 | SteelSeries Arctis Nova 7 | All | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |
-| SteelSeries Arctis Nova 7 Wireless Gen 2 | All | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |
+| SteelSeries Arctis Nova (7/7x) Wireless Gen 2 | All | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |
 | SteelSeries Arctis 7+ | All | x | x |   |   | x | x |   |   | x | x |   |   |   |   |   |   |
 | SteelSeries Arctis Nova Pro Wireless | All | x | x |   | x | x |   |   |   | x | x |   |   |   |   |   |   |
 | HeadsetControl Test device | All | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |

--- a/src/devices/steelseries_arctis_nova_7.c
+++ b/src/devices/steelseries_arctis_nova_7.c
@@ -12,6 +12,7 @@ static struct device device_arctis;
 
 #define ID_ARCTIS_NOVA_7           0x2202
 #define ID_ARCTIS_NOVA_7_WIRELESS  0x227e
+#define ID_ARCTIS_NOVA_7x_WIRELESS 0x229e
 #define ID_ARCTIS_NOVA_7x          0x2206
 #define ID_ARCTIS_NOVA_7x_v2       0x2258
 #define ID_ARCTIS_NOVA_7p          0x220a
@@ -31,7 +32,7 @@ static struct device device_arctis;
 #define EQUALIZER_BAND_MAX      +10
 #define EQUALIZER_PRESETS_COUNT 4
 
-static const uint16_t PRODUCT_IDS[]      = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7_WIRELESS, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7x_v2, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV, ID_ARCTIS_NOVA_7_WOW_ED };
+static const uint16_t PRODUCT_IDS[]      = { ID_ARCTIS_NOVA_7, ID_ARCTIS_NOVA_7_WIRELESS, ID_ARCTIS_NOVA_7x_WIRELESS, ID_ARCTIS_NOVA_7x, ID_ARCTIS_NOVA_7x_v2, ID_ARCTIS_NOVA_7p, ID_ARCTIS_NOVA_7_DIABLO_IV, ID_ARCTIS_NOVA_7_WOW_ED };
 static const uint8_t SAVE_DATA[MSG_SIZE] = { 0x06, 0x09 };
 
 float flat[EQUALIZER_BANDS_COUNT]   = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
### Changes made

Adds partial support for SteelSeries Arctis Nova 7x Wireless Gen 2 by adding the appropriate device ID, mirroring previously merged SteelSeries Arctis Nova 7 Wireless Gen 2 support.

### Checklist

- [x] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
