### PR TITLE
Add top level project guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,29 +266,29 @@ endif()
 # CLI Executable
 # ------------------------------------------------------------------------------
 
-# Create the CLI executable that links against the library
-# On Windows, include the resource file for the application icon
-if(WIN32)
-    set(WIN_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/assets/headsetcontrol.rc)
-    # Ensure resource compiler can find the icon file
-    set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}/assets")
-endif()
-
-add_executable(headsetcontrol ${CLI_SOURCES} ${WIN_RESOURCES})
-target_link_libraries(headsetcontrol PRIVATE headsetcontrol_lib)
-target_include_directories(headsetcontrol PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cli)
-
-# On MSVC, we need getopt from vcpkg
-if(MSVC)
-    find_package(getopt CONFIG REQUIRED)
-    target_link_libraries(headsetcontrol PRIVATE $<IF:$<TARGET_EXISTS:getopt::getopt_shared>,getopt::getopt_shared,getopt::getopt_static>)
-endif()
-
-# ------------------------------------------------------------------------------
-# Installation
-# ------------------------------------------------------------------------------
-
 if(PROJECT_IS_TOP_LEVEL)
+
+    # Create the CLI executable that links against the library
+    # On Windows, include the resource file for the application icon
+    if(WIN32)
+        set(WIN_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/assets/headsetcontrol.rc)
+        # Ensure resource compiler can find the icon file
+        set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}/assets")
+    endif()
+
+    add_executable(headsetcontrol ${CLI_SOURCES} ${WIN_RESOURCES})
+    target_link_libraries(headsetcontrol PRIVATE headsetcontrol_lib)
+    target_include_directories(headsetcontrol PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cli)
+
+    # On MSVC, we need getopt from vcpkg
+    if(MSVC)
+        find_package(getopt CONFIG REQUIRED)
+        target_link_libraries(headsetcontrol PRIVATE $<IF:$<TARGET_EXISTS:getopt::getopt_shared>,getopt::getopt_shared,getopt::getopt_static>)
+    endif()
+
+    # ------------------------------------------------------------------------------
+    # Installation
+    # ------------------------------------------------------------------------------
 
     install(TARGETS headsetcontrol DESTINATION bin)
     install(TARGETS headsetcontrol_lib DESTINATION lib)
@@ -307,21 +307,21 @@ if(PROJECT_IS_TOP_LEVEL)
         DESTINATION include/headsetcontrol
     )
 
-endif()
+    # install udev files on linux
+    if(UNIX AND NOT APPLE AND NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
+        set(rules_file 70-headsets.rules)
+        set(udev_rules_dir lib/udev/rules.d/
+            CACHE PATH "Path to the directory where udev rules should be installed")
+        add_custom_command(
+            OUTPUT ${rules_file}
+            COMMAND headsetcontrol -u > ${rules_file}
+            DEPENDS headsetcontrol)
+        add_custom_target(udevrules ALL DEPENDS ${rules_file})
+        install(
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/${rules_file}
+            DESTINATION ${udev_rules_dir})
+    endif()
 
-# install udev files on linux
-if(UNIX AND NOT APPLE AND NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(rules_file 70-headsets.rules)
-    set(udev_rules_dir lib/udev/rules.d/
-        CACHE PATH "Path to the directory where udev rules should be installed")
-    add_custom_command(
-        OUTPUT ${rules_file}
-        COMMAND headsetcontrol -u > ${rules_file}
-        DEPENDS headsetcontrol)
-    add_custom_target(udevrules ALL DEPENDS ${rules_file})
-    install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/${rules_file}
-        DESTINATION ${udev_rules_dir})
 endif()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Since the recommended way to use the headsetcontrol library is as a subdirectory. Some configuring steps should be disabled. This PR adds a top level project guard to disable some configuring steps that are unnecessary when using as a subdirectory or with [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html).

This leverages [`PROJECT_IS_TOP_LEVEL`](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) variable, which is available since CMake's 3.21. With older version, we fall back to check whether `CMAKE_SOURCE_DIR` is equal to `PROJECT_SOURCE_DIR`.

Potential problem: In this patch I also put the build CLI executable step and generating udev rules step behind the guard. Should generating udev contents also be available through API and let the library consumers handle it themselves? Or the generating udev rules step should not be put behind the guard?