### PR TITLE
Add additional Steelseries Arctis Nova 7X v2 id

### DIFF
--- a/lib/devices/steelseries_arctis_nova_7.hpp
+++ b/lib/devices/steelseries_arctis_nova_7.hpp
@@ -37,12 +37,12 @@ public:
         0x227a // Arctis Nova 7 WoW Edition
     };
 
-    static constexpr int EQUALIZER_BANDS          = 10;
-    static constexpr float EQUALIZER_BAND_MIN     = -10.0f;
-    static constexpr float EQUALIZER_BAND_MAX     = 10.0f;
-    static constexpr float EQUALIZER_BAND_STEP    = 0.5f;
-    static constexpr int EQUALIZER_BASELINE       = 0x14; // 20 decimal
-    static constexpr int EQUALIZER_PRESETS_COUNT  = 4;
+    static constexpr int EQUALIZER_BANDS         = 10;
+    static constexpr float EQUALIZER_BAND_MIN    = -10.0f;
+    static constexpr float EQUALIZER_BAND_MAX    = 10.0f;
+    static constexpr float EQUALIZER_BAND_STEP   = 0.5f;
+    static constexpr int EQUALIZER_BASELINE      = 0x14; // 20 decimal
+    static constexpr int EQUALIZER_PRESETS_COUNT = 4;
 
     // Preset arrays (flat, bass, focus, smiley)
     static constexpr std::array<float, EQUALIZER_BANDS> PRESET_FLAT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
For some reason my nova 7x v2 has an unknown id.
`Bus 003 Device 008: ID 1038:229e SteelSeries ApS Arctis Nova 7X Gen 2`

Chatmixvalue is reported correctly, battery remains at 100% tho

### Changes made

<!--- Describe your changes here --->.
* Include productId **229e**

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
