### PR TITLE
Separate Nova 7P into its own device class without sidetone/chatmix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ A cross-platform tool to control USB gaming headsets on **Linux**, **macOS**, an
 | SteelSeries Arctis Pro Wireless | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis Nova 3 | All | x |   |   |   |   |   |   |   | x | x |   | x | x |   |   |   |
 | SteelSeries Arctis Nova (5/5X) | All | x | x |   |   | x | x |   |   | x | x | x | x | x | x |   |   |
-| SteelSeries Arctis Nova 7 | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
+| SteelSeries Arctis Nova 7 | All | x | x |   |   | x | x |   |   | x | x |   | x | x | x | x | x |
+| SteelSeries Arctis Nova 7P | All |   | x |   |   | x |   |   |   | x | x |   | x | x | x | x | x |
 | SteelSeries Arctis 7+ | All | x | x |   |   | x | x |   |   | x | x |   |   |   |   |   |   |
 | SteelSeries Arctis Nova Pro Wireless | All | x | x |   | x | x |   |   |   | x | x |   |   |   |   |   |   |
 | SteelSeries Arctis Nova 3P Wireless | L/M | x | x |   |   | x |   |   |   | x | x | x |   | x |   |   |   |

--- a/lib/device_registry.cpp
+++ b/lib/device_registry.cpp
@@ -21,6 +21,7 @@
 #include "devices/steelseries_arctis_nova_3p_wireless.hpp"
 #include "devices/steelseries_arctis_nova_5.hpp"
 #include "devices/steelseries_arctis_nova_7.hpp"
+#include "devices/steelseries_arctis_nova_7p.hpp"
 #include "devices/steelseries_arctis_nova_pro_wireless.hpp"
 #include "devices/steelseries_arctis_pro_wireless.hpp"
 
@@ -98,6 +99,7 @@ void DeviceRegistry::initialize()
         registerDevice(std::make_unique<SteelSeriesArctisNova3>());
         registerDevice(std::make_unique<SteelSeriesArctisNova5>());
         registerDevice(std::make_unique<SteelSeriesArctisNova7>());
+        registerDevice(std::make_unique<SteelSeriesArctisNova7P>());
         registerDevice(std::make_unique<SteelSeriesArctis7Plus>());
         registerDevice(std::make_unique<SteelSeriesArctisNovaProWireless>());
         registerDevice(std::make_unique<SteelSeriesArctisNova3PWireless>());

--- a/lib/devices/steelseries_arctis_nova_7.hpp
+++ b/lib/devices/steelseries_arctis_nova_7.hpp
@@ -11,7 +11,7 @@ using namespace std::string_view_literals;
 namespace headsetcontrol {
 
 /**
- * @brief SteelSeries Arctis Nova 7/7X/7P Gaming Headset
+ * @brief SteelSeries Arctis Nova 7/7X Gaming Headset
  *
  * Features:
  * - Sidetone (4 levels)
@@ -23,16 +23,18 @@ namespace headsetcontrol {
  * - Microphone volume (8 levels)
  * - Volume limiter
  * - Bluetooth settings
+ *
+ * Note: Nova 7P (0x220a) is handled by SteelSeriesArctisNova7P due to
+ * different hardware behavior (no working sidetone/chatmix).
  */
 class SteelSeriesArctisNova7 : public protocols::SteelSeriesNovaDevice<SteelSeriesArctisNova7> {
 public:
-    static constexpr std::array<uint16_t, 8> SUPPORTED_PRODUCT_IDS {
+    static constexpr std::array<uint16_t, 7> SUPPORTED_PRODUCT_IDS {
         0x2202, // Arctis Nova 7
         0x227e, // Arctis Nova 7 Wireless
         0x2206, // Arctis Nova 7x
         0x2258, // Arctis Nova 7x v2
         0x229e, // Arctis Nova 7x v2
-        0x220a, // Arctis Nova 7p
         0x223a, // Arctis Nova 7 Diablo IV
         0x227a // Arctis Nova 7 WoW Edition
     };

--- a/lib/devices/steelseries_arctis_nova_7p.hpp
+++ b/lib/devices/steelseries_arctis_nova_7p.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "steelseries_arctis_nova_7.hpp"
+
+namespace headsetcontrol {
+
+/**
+ * @brief SteelSeries Arctis Nova 7P Gaming Headset
+ *
+ * The Nova 7P is a variant of the Nova 7 with different hardware behavior:
+ * - The dial controls sidetone instead of chatmix, but sidetone setting doesn't work
+ * - Chatmix always returns a fixed value (64)
+ *
+ * This class inherits from Nova 7 and disables the non-functional capabilities.
+ * See: https://github.com/Sapd/HeadsetControl/issues/450
+ */
+class SteelSeriesArctisNova7P : public SteelSeriesArctisNova7 {
+public:
+    std::vector<uint16_t> getProductIds() const override
+    {
+        return { 0x220a }; // Arctis Nova 7P only
+    }
+
+    std::string_view getDeviceName() const override
+    {
+        return "SteelSeries Arctis Nova 7P"sv;
+    }
+
+    constexpr int getCapabilities() const override
+    {
+        // Nova 7P does not support sidetone or chatmix
+        // (sidetone setting has no effect, chatmix always returns 64)
+        return B(CAP_BATTERY_STATUS)
+            | B(CAP_INACTIVE_TIME) | B(CAP_EQUALIZER) | B(CAP_EQUALIZER_PRESET)
+            | B(CAP_MICROPHONE_MUTE_LED_BRIGHTNESS) | B(CAP_MICROPHONE_VOLUME)
+            | B(CAP_VOLUME_LIMITER) | B(CAP_BT_WHEN_POWERED_ON) | B(CAP_BT_CALL_VOLUME);
+    }
+};
+} // namespace headsetcontrol


### PR DESCRIPTION
Fixes #450 - The Arctis Nova 7P has different hardware behavior compared to the Nova 7/7X variants:
- The dial controls sidetone instead of chatmix
- Sidetone setting has no effect
- Chatmix always returns a fixed value (64)

This commit creates a separate SteelSeriesArctisNova7P class that inherits from SteelSeriesArctisNova7 but disables CAP_SIDETONE and CAP_CHATMIX_STATUS.

Changes:
- Add new steelseries_arctis_nova_7p.hpp with Nova 7P-specific class
- Remove 0x220a (Nova 7P) from Nova 7 device class
- Register Nova 7P as separate device in device_registry.cpp
- Update README.md device table
