### PR TITLE
 Nova 7  Diablo 

### DIFF
--- a/lib/devices/steelseries_arctis_nova_7.hpp
+++ b/lib/devices/steelseries_arctis_nova_7.hpp
@@ -35,7 +35,7 @@ public:
         0x2206, // Arctis Nova 7x
         0x2258, // Arctis Nova 7x v2
         0x229e, // Arctis Nova 7x v2
-	0x223a,  // Arctis Nova 7 Diablo IV (before Jan Update)
+        0x223a,  // Arctis Nova 7 Diablo IV (before Jan Update)
         0x22a9, // Arctis Nova 7 Diablo IV (after Jan Update)
         0x227a // Arctis Nova 7 WoW Edition
     };


### PR DESCRIPTION
0x223a changed to 0x22a9

### Changes made

0x223a changed to 0x22a9 in [lib/devices/steelseries_arctis_nova_7.hpp](https://github.com/Sapd/HeadsetControl/compare/master...handy142:HeadsetControl:Nova-7-Fix?expand=1#diff-9b2e3e5f45d62eac63eb4c0722eaf46e2a90e4b6d5732f2d33ac6eb1042d1f3e)

