### PR TITLE
Fix inverted ChatMix level for SteelSeries Arctis 7/Pro (#475)

### DIFF
--- a/lib/devices/steelseries_arctis_7.hpp
+++ b/lib/devices/steelseries_arctis_7.hpp
@@ -167,8 +167,8 @@ public:
         }
 
         // Calculate percentages (game/chat are 191-255, neutral at 255)
-        int game_pct = (game == 0) ? 100 : map(game, 191, 255, 100, 0);
-        int chat_pct = (chat == 0) ? 100 : map(chat, 191, 255, 100, 0);
+        int game_pct = (game == 0) ? 100 : map(game, 191, 255, 0, 100);
+        int chat_pct = (chat == 0) ? 100 : map(chat, 191, 255, 0, 100);
 
         return ChatmixResult {
             .level               = level,


### PR DESCRIPTION
The chatmix level calculation had game and chat directions swapped: max game volume produced level > 64 (indicating chat), and vice versa.

This bug originated in the old C implementation (steelseries_arctis_7.c) and was carried over verbatim during the C++ rewrite (#443). It went unnoticed because the old code returned a plain int with no defined semantics for direction, users just saw a changing number. The bug became observable once ChatmixResult defined < 64 as game and > 64 as chat.
