### PR TITLE
changed interface id from 0 to 4 for Arctis Nova 3P Wireless

### DIFF
--- a/lib/devices/steelseries_arctis_nova_3p_wireless.hpp
+++ b/lib/devices/steelseries_arctis_nova_3p_wireless.hpp
@@ -103,7 +103,7 @@ public:
 
     constexpr capability_detail getCapabilityDetail([[maybe_unused]] enum capabilities cap) const override
     {
-        return { .usagepage = 0xffc0, .usageid = 0x1, .interface_id = 0 };
+        return { .usagepage = 0xffc0, .usageid = 0x1, .interface_id = 4 };
     }
 
     constexpr uint8_t getSupportedPlatforms() const override


### PR DESCRIPTION
### Changes made

Changed the interface id from 0 to 4 to fix non detection for Steelseries Arctis Nova 3P Wireless on Linux.

This is the output of the device information for clarification. 
Device Found
  VendorID: 0x1038
 ProductID: 0x2269
  path: /dev/hidraw2
  serial_number:
  Manufacturer: SteelSeries
  Product:      Arctis Nova 3P Wireless
  Interface:    3
  Usage-Page: 0xffc0 Usageid: 0x1

Device Found
  VendorID: 0x1038
 ProductID: 0x2269
  path: /dev/hidraw1
  serial_number:
  Manufacturer: SteelSeries
  Product:      Arctis Nova 3P Wireless
  Interface:    4
  Usage-Page: 0xc Usageid: 0x1

Device Found
  VendorID: 0x1038
 ProductID: 0x2269
  path: /dev/hidraw0
  serial_number:
  Manufacturer: SteelSeries
  Product:      Arctis Nova 3P Wireless
  Interface:    5
  Usage-Page: 0xff00 Usageid: 0x1

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
