### PR TITLE
Add support for Arctis Nova 7X (PIDs 0x22a4, 0x22a5)

### DIFF
--- a/lib/devices/steelseries_arctis_nova_7.hpp
+++ b/lib/devices/steelseries_arctis_nova_7.hpp
@@ -38,9 +38,9 @@ public:
         0x229e, // Arctis Nova 7x v2 (percentage battery: 0-100)
         0x223a, // Arctis Nova 7 Diablo IV (discrete battery: 0-4, before Jan 2026 update)
         0x22a9, // Arctis Nova 7 Diablo IV (percentage battery: 0-100, after Jan 2026 update)
-        0x227a // Arctis Nova 7 WoW Edition (discrete battery: 0-4)
+        0x227a, // Arctis Nova 7 WoW Edition (discrete battery: 0-4)
         0x22a4, // Arctis Nova 7X (discrete battery: 0-4)
-        0x22a5 // Arctis Nova 7X (percentage battery: 0-100)
+        0x22a5  // Arctis Nova 7X (percentage battery: 0-100)
     };
 
     static constexpr int EQUALIZER_BANDS         = 10;


### PR DESCRIPTION
Added support for the newer firmware/revision IDs of the Arctis Nova 7X (0x22a4 and 0x22a5) based on community reports (Issue #471 and #479). Tested locally and confirmed battery reporting works.