### PR TITLE
Adding G431 product id

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A cross-platform tool to control USB gaming headsets on **Linux**, **macOS**, an
 | Logitech G533 | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G535 | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G633/G635/G733/G933/G935 | All | x | x |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
-| Logitech G432/G433 | All | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G431/G432/G433 | All | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G930 | All | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G PRO Series | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech Zone Wired/Zone 750 | All | x |   |   |   |   |   | x | x |   |   |   |   |   |   |   |   |

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ A cross-platform tool to control USB gaming headsets on **Linux**, **macOS**, an
 
 | Device | Platform | sidetone | battery | notification sound | lights | inactive time | chatmix | voice prompts | rotate to mute | equalizer preset | equalizer | parametric equalizer | microphone mute led brightness | microphone volume | volume limiter | bluetooth when powered on | bluetooth call volume |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Logitech G522 Lightspeed | All | x | x |   |   | x |   |   |   |   |   |   | x |   |   |   |   |
+| Logitech G522 LIGHTSPEED | All | x | x |   |   | x |   |   |   |   |   |   | x |   |   |   |   |
 | Logitech G533 | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G535 | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G633/G635/G733/G933/G935 | All | x | x |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G431/G432/G433 | All | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G930 | All | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Logitech G PRO X 2 LIGHTSPEED | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech G PRO Series | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | Logitech Zone Wired/Zone 750 | All | x |   |   |   |   |   | x | x |   |   |   |   |   |   |   |   |
 | Corsair Headset Device | All | x | x | x | x |   |   |   |   |   |   |   |   |   |   |   |   |
-| Corsair Wireless V2 | All | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Corsair Wireless V2 Headset Device | All | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis (1/7X/7P) Wireless | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis (7/Pro) | All | x | x |   | x | x | x |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis 9 | All | x | x |   |   | x | x |   |   |   |   |   |   |   |   |   |   |
@@ -46,7 +47,7 @@ A cross-platform tool to control USB gaming headsets on **Linux**, **macOS**, an
 | ROCCAT Elo 7.1 Air | All |   |   |   | x | x |   |   |   |   |   |   |   |   |   |   |   |
 | ROCCAT Elo 7.1 USB | All |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | Audeze Maxwell | All | x | x |   |   | x | x | x |   | x |   |   |   |   | x |   |   |
-| Lenovo Wireless VoIP Headset | All | x | x |   |   | x |   | x | x | x |   |   |   |   | x |   |   |
+| Lenovo Wireless VoIP Headset | All | x | x |   |   | x |   | x | x | x |   |   | x |   | x |   |   |
 | Sony INZONE Buds | All |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | HeadsetControl Test device | All | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x | x |
 

--- a/lib/devices/logitech_g432.hpp
+++ b/lib/devices/logitech_g432.hpp
@@ -30,7 +30,7 @@ public:
 
     std::string_view getDeviceName() const override
     {
-        return "Logitech G432/G433"sv;
+        return "Logitech G431/G432/G433"sv;
     }
 
     constexpr int getCapabilities() const override

--- a/lib/devices/logitech_g432.hpp
+++ b/lib/devices/logitech_g432.hpp
@@ -9,7 +9,7 @@ using namespace std::string_view_literals;
 namespace headsetcontrol {
 
 /**
- * @brief Logitech G432/G433 Gaming Headsets
+ * @brief Logitech G431/G432/G433 Gaming Headsets
  *
  * These are simpler USB headsets with limited features.
  * Currently only sidetone is supported.
@@ -22,6 +22,7 @@ public:
     std::vector<uint16_t> getProductIds() const override
     {
         return {
+            0x0a9b, // G431
             0x0a9c, // G432
             0x0a6d // G433
         };


### PR DESCRIPTION
### Changes made

Just got a new G431 headset (Logitech), but struggled to edit the sidetone on it.
Adding the product ID worked in my case to manage this setting.


### Checklist

- [X] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)

By the way, thanks for this great tool !