### PR TITLE
feat(device): add HyperX Cloud II Wireless (Kingston)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A cross-platform tool to control USB gaming headsets on **Linux**, **macOS**, an
 | HyperX Cloud Flight Wireless | All |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | HyperX Cloud II Wireless | All |   | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | HyperX Cloud 3 | All | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| HyperX Cloud II Wireless (Kingston) | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | ROCCAT Elo 7.1 Air | All |   |   |   | x | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | ROCCAT Elo 7.1 USB | All |   |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Audeze Maxwell | All | x | x |   |   | x | x | x |   | x |   |   |   |   | x |   |   |   |

--- a/lib/device_registry.cpp
+++ b/lib/device_registry.cpp
@@ -30,6 +30,7 @@
 
 // HyperX devices
 #include "devices/hyperx_cloud_2_wireless.hpp"
+#include "devices/hyperx_cloud_2_wireless_kingston.hpp"
 #include "devices/hyperx_cloud_3.hpp"
 #include "devices/hyperx_cloud_alpha_wireless.hpp"
 #include "devices/hyperx_cloud_flight.hpp"
@@ -121,6 +122,7 @@ void DeviceRegistry::initialize()
         registerDevice(std::make_unique<HyperXCloudAlphaWireless>());
         registerDevice(std::make_unique<HyperXCloudFlight>());
         registerDevice(std::make_unique<HyperXCloud2Wireless>());
+        registerDevice(std::make_unique<HyperXCloud2WirelessKingston>());
         registerDevice(std::make_unique<HyperXCloud3>());
 
         // Roccat devices

--- a/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
+++ b/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "../result_types.hpp"
+#include "hid_device.hpp"
+#include <array>
+#include <chrono>
+#include <string_view>
+#include <thread>
+
+using namespace std::string_view_literals;
+
+namespace headsetcontrol {
+
+/**
+ * @brief HyperX Cloud II Wireless Gaming Headset (Kingston-branded revision)
+ *
+ * Uses a different protocol than the HP-branded version (0x03f0:0x0696).
+ * Protocol reverse-engineered from HyperHeadset project:
+ * https://github.com/LennardKittner/HyperHeadset
+ *
+ * Key differences:
+ * - 62-byte packets instead of 52
+ * - Different base packet structure
+ * - Response uses Report ID 11 (0x0B) instead of 6
+ * - Battery level at response[7]
+ */
+class HyperXCloud2WirelessKingston : public HIDDevice {
+public:
+    static constexpr uint16_t VENDOR_KINGSTON = 0x0951;
+    static constexpr std::array<uint16_t, 1> SUPPORTED_PRODUCT_IDS_KINGSTON {
+        0x1718 // Cloud II Wireless (Kingston)
+    };
+
+    static constexpr int WRITE_PACKET_SIZE = 62;
+    static constexpr int WRITE_TIMEOUT     = 100;
+    static constexpr int READ_PACKET_SIZE  = 64;
+    static constexpr int READ_TIMEOUT      = 1000;
+
+    static constexpr uint8_t CMD_GET_BATTERY_LEVEL    = 0x02;
+    static constexpr uint8_t CMD_GET_BATTERY_CHARGING = 0x03;
+    static constexpr uint8_t CMD_SET_AUTO_SHUTDOWN    = 0x18;
+    static constexpr uint8_t CMD_SET_SIDETONE         = 0x19;
+
+    static constexpr int BATTERY_LEVEL_INDEX   = 7;
+    static constexpr int CHARGING_STATUS_INDEX = 4;
+
+    constexpr uint16_t getVendorId() const override
+    {
+        return VENDOR_KINGSTON;
+    }
+
+    std::vector<uint16_t> getProductIds() const override
+    {
+        return { SUPPORTED_PRODUCT_IDS_KINGSTON.begin(), SUPPORTED_PRODUCT_IDS_KINGSTON.end() };
+    }
+
+    std::string_view getDeviceName() const override
+    {
+        return "HyperX Cloud II Wireless (Kingston)"sv;
+    }
+
+    constexpr int getCapabilities() const override
+    {
+        return B(CAP_BATTERY_STATUS) | B(CAP_SIDETONE) | B(CAP_INACTIVE_TIME);
+    }
+
+    Result<std::array<uint8_t, READ_PACKET_SIZE>> sendCommand(hid_device* device_handle, uint8_t command, uint8_t payload = 0, bool check_response = true)
+    {
+        // Base packet structure from HyperHeadset
+        std::array<uint8_t, WRITE_PACKET_SIZE> request { };
+        request[0]  = 0x06;
+        request[1]  = 0x00;
+        request[2]  = 0x02;
+        request[3]  = 0x00;
+        request[4]  = 0x9A;
+        request[5]  = 0x00;
+        request[6]  = 0x00;
+        request[7]  = 0x68;
+        request[8]  = 0x4A;
+        request[9]  = 0x8E;
+        request[10] = 0x0A;
+        request[11] = 0x00;
+        request[12] = 0x00;
+        request[13] = 0x00;
+        request[14] = 0xBB;
+        request[15] = command;
+        request[16] = payload;
+
+        // Prepare write: attempt to read input report first (may fail, ignore error)
+        std::array<uint8_t, 64> input_report { };
+        input_report[0] = 0x06;
+        hid_get_input_report(device_handle, input_report.data(), input_report.size());
+
+        auto wr = writeHID(device_handle, request);
+        std::this_thread::sleep_for(std::chrono::milliseconds(WRITE_TIMEOUT));
+        if (!wr) {
+            return wr.error();
+        }
+
+        std::array<uint8_t, READ_PACKET_SIZE> response { };
+        auto rd = readHIDTimeout(device_handle, response, READ_TIMEOUT);
+
+        if (!check_response) {
+            return response;
+        }
+
+        if (!rd) {
+            return rd.error();
+        }
+
+        // Response format: [11, 0, 187, cmd_id, ...]
+        if (response[0] != 0x0B || response[2] != 0xBB || response[3] != command) {
+            return DeviceError::protocolError("Invalid response header");
+        }
+
+        return response;
+    }
+
+    Result<BatteryResult> getBattery(hid_device* device_handle) override
+    {
+        auto level_res = sendCommand(device_handle, CMD_GET_BATTERY_LEVEL);
+        if (!level_res) {
+            return level_res.error();
+        }
+
+        auto charging_res = sendCommand(device_handle, CMD_GET_BATTERY_CHARGING);
+        if (!charging_res) {
+            return charging_res.error();
+        }
+
+        return BatteryResult {
+            .level_percent = (*level_res)[BATTERY_LEVEL_INDEX],
+            .status        = ((*charging_res)[CHARGING_STATUS_INDEX] == 1) ? BATTERY_CHARGING : BATTERY_AVAILABLE,
+            .voltage_mv    = -1,
+            .raw_data      = std::vector<uint8_t>(level_res->begin(), level_res->end())
+        };
+    }
+
+    Result<SidetoneResult> setSidetone(hid_device* device_handle, uint8_t level) override
+    {
+        // Protocol only supports binary on/off (1 or 0)
+        uint8_t hardware_level = (level > 0) ? 1 : 0;
+        auto res               = sendCommand(device_handle, CMD_SET_SIDETONE, hardware_level, false);
+        if (!res) {
+            return res.error();
+        }
+
+        return SidetoneResult {
+            .current_level = level,
+            .min_level     = 0,
+            .max_level     = 128,
+            .device_min    = 0,
+            .device_max    = 1
+        };
+    }
+
+    Result<InactiveTimeResult> setInactiveTime(hid_device* device_handle, uint8_t minutes) override
+    {
+        // Hardware limit: 30 minutes maximum
+        uint8_t hardware_mins = (minutes > 30) ? 30 : minutes;
+        auto res              = sendCommand(device_handle, CMD_SET_AUTO_SHUTDOWN, hardware_mins);
+        if (!res) {
+            return res.error();
+        }
+
+        return InactiveTimeResult {
+            .minutes     = hardware_mins,
+            .min_minutes = 0,
+            .max_minutes = 30
+        };
+    }
+};
+
+} // namespace headsetcontrol

--- a/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
+++ b/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
@@ -64,9 +64,9 @@ public:
         return B(CAP_BATTERY_STATUS) | B(CAP_SIDETONE) | B(CAP_INACTIVE_TIME);
     }
 
-    Result<std::array<uint8_t, READ_PACKET_SIZE>> sendCommand(hid_device* device_handle, uint8_t command, uint8_t payload = 0, bool check_response = true)
+private:
+    std::array<uint8_t, WRITE_PACKET_SIZE> buildRequest(uint8_t command, uint8_t payload = 0) const
     {
-        // Base packet structure from HyperHeadset
         std::array<uint8_t, WRITE_PACKET_SIZE> request { };
         request[0]  = 0x06;
         request[1]  = 0x00;
@@ -85,11 +85,22 @@ public:
         request[14] = 0xBB;
         request[15] = command;
         request[16] = payload;
+        return request;
+    }
 
-        // Prepare write: attempt to read input report first (may fail, ignore error)
+    void prepareDevice(hid_device* device_handle) const
+    {
         std::array<uint8_t, 64> input_report { };
         input_report[0] = 0x06;
-        hid_get_input_report(device_handle, input_report.data(), input_report.size());
+        // Attempt to read input report before writing (may fail, ignore error)
+        [[maybe_unused]] auto _ = getInputReport(device_handle, input_report);
+    }
+
+public:
+    Result<std::array<uint8_t, READ_PACKET_SIZE>> sendCommand(hid_device* device_handle, uint8_t command, uint8_t payload = 0)
+    {
+        auto request = buildRequest(command, payload);
+        prepareDevice(device_handle);
 
         auto wr = writeHID(device_handle, request);
         std::this_thread::sleep_for(std::chrono::milliseconds(WRITE_TIMEOUT));
@@ -99,10 +110,6 @@ public:
 
         std::array<uint8_t, READ_PACKET_SIZE> response { };
         auto rd = readHIDTimeout(device_handle, response, READ_TIMEOUT);
-
-        if (!check_response) {
-            return response;
-        }
 
         if (!rd) {
             return rd.error();
@@ -114,6 +121,13 @@ public:
         }
 
         return response;
+    }
+
+    Result<void> sendCommandFireAndForget(hid_device* device_handle, uint8_t command, uint8_t payload = 0)
+    {
+        auto request = buildRequest(command, payload);
+        prepareDevice(device_handle);
+        return writeHID(device_handle, request);
     }
 
     Result<BatteryResult> getBattery(hid_device* device_handle) override
@@ -130,9 +144,9 @@ public:
 
         return BatteryResult {
             .level_percent = (*level_res)[BATTERY_LEVEL_INDEX],
-            .status        = ((*charging_res)[CHARGING_STATUS_INDEX] == 1) ? BATTERY_CHARGING : BATTERY_AVAILABLE,
-            .voltage_mv    = -1,
-            .raw_data      = std::vector<uint8_t>(level_res->begin(), level_res->end())
+            .status = ((*charging_res)[CHARGING_STATUS_INDEX] == 1) ? BATTERY_CHARGING : BATTERY_AVAILABLE,
+            .voltage_mv = std::nullopt,
+            .raw_data = std::vector<uint8_t>(level_res->begin(), level_res->end())
         };
     }
 
@@ -140,17 +154,17 @@ public:
     {
         // Protocol only supports binary on/off (1 or 0)
         uint8_t hardware_level = (level > 0) ? 1 : 0;
-        auto res               = sendCommand(device_handle, CMD_SET_SIDETONE, hardware_level, false);
+        auto res = sendCommandFireAndForget(device_handle, CMD_SET_SIDETONE, hardware_level);
         if (!res) {
             return res.error();
         }
 
         return SidetoneResult {
-            .current_level = level,
-            .min_level     = 0,
-            .max_level     = 128,
-            .device_min    = 0,
-            .device_max    = 1
+            .current_level = hardware_level,
+            .min_level = 0,
+            .max_level = 128,
+            .device_min = 0,
+            .device_max = 1
         };
     }
 
@@ -158,13 +172,13 @@ public:
     {
         // Hardware limit: 30 minutes maximum
         uint8_t hardware_mins = (minutes > 30) ? 30 : minutes;
-        auto res              = sendCommand(device_handle, CMD_SET_AUTO_SHUTDOWN, hardware_mins);
+        auto res = sendCommand(device_handle, CMD_SET_AUTO_SHUTDOWN, hardware_mins);
         if (!res) {
             return res.error();
         }
 
         return InactiveTimeResult {
-            .minutes     = hardware_mins,
+            .minutes = hardware_mins,
             .min_minutes = 0,
             .max_minutes = 30
         };

--- a/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
+++ b/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
@@ -99,7 +99,7 @@ private:
 public:
     Result<std::array<uint8_t, READ_PACKET_SIZE>> sendCommand(hid_device* device_handle, uint8_t command, uint8_t payload = 0)
     {
-        auto request = buildRequest(command, payload);
+        prepareDevice(device_handle);
         prepareDevice(device_handle);
 
         auto wr = writeHID(device_handle, request);

--- a/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
+++ b/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
@@ -125,7 +125,7 @@ public:
 
     Result<void> sendCommandFireAndForget(hid_device* device_handle, uint8_t command, uint8_t payload = 0)
     {
-        auto request = buildRequest(command, payload);
+        prepareDevice(device_handle);
         prepareDevice(device_handle);
         return writeHID(device_handle, request);
     }

--- a/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
+++ b/lib/devices/hyperx_cloud_2_wireless_kingston.hpp
@@ -100,7 +100,7 @@ public:
     Result<std::array<uint8_t, READ_PACKET_SIZE>> sendCommand(hid_device* device_handle, uint8_t command, uint8_t payload = 0)
     {
         prepareDevice(device_handle);
-        prepareDevice(device_handle);
+        auto request = buildRequest(command, payload);
 
         auto wr = writeHID(device_handle, request);
         std::this_thread::sleep_for(std::chrono::milliseconds(WRITE_TIMEOUT));
@@ -126,7 +126,7 @@ public:
     Result<void> sendCommandFireAndForget(hid_device* device_handle, uint8_t command, uint8_t payload = 0)
     {
         prepareDevice(device_handle);
-        prepareDevice(device_handle);
+        auto request = buildRequest(command, payload);
         return writeHID(device_handle, request);
     }
 


### PR DESCRIPTION
### Changes made

Added support for the **HyperX Cloud II Wireless (Kingston revision)** headset. 

Features implemented:
- Sidetone (mic monitoring) toggle control
- Battery level reporting
- Inactive time configuration

I have tested these features locally and confirmed they are working correctly with the headset.

### Checklist

- [x] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)