### PR TITLE
add HyperX Cloud III Wired 2026

### DIFF
--- a/lib/devices/hyperx_cloud_3.hpp
+++ b/lib/devices/hyperx_cloud_3.hpp
@@ -20,8 +20,9 @@ namespace headsetcontrol {
 class HyperXCloud3 : public HIDDevice {
 public:
     static constexpr uint16_t VENDOR_HYPERX_CLOUD = 0x03f0;
-    static constexpr std::array<uint16_t, 1> SUPPORTED_PRODUCT_IDS {
-        0x089d // Cloud 3 Wired
+    static constexpr std::array<uint16_t, 2> SUPPORTED_PRODUCT_IDS {
+        0x089d, // Cloud 3 Wired
+        0x03cc, // Cloud 3 Wired 2026
     };
 
     static constexpr int MSG_SIZE = 62;


### PR DESCRIPTION
### Changes made

I've added a new product ID for the HyperX Cloud III Wired. There may have been a model refresh or something, I'm not sure. This is using the USB C to 3.5 mm adapter that came with the headset.

After adding this ID, I was able to successfully enable the (unfortunately very quiet) sidetone on my headset! And here's some output confirming the connection:

```
❯ headsetcontrol -o yaml
---
name: "HeadsetControl"
version: "continuous-45-g5ef0eae-modified"
api_version: "1.4"
hidapi_version: "0.15.0"
device_count: 1
devices:
  - status: "success"
    device: "HyperX Cloud 3"
    vendor: "HP, Inc"
    product: "HyperX Cloud III"
    id_vendor: "0x03f0"
    id_product: "0x03cc"
    capabilities:
      - CAP_SIDETONE
    capabilities_str:
      - sidetone
```

Thanks for building this great tool! And the docs were very helpful.

### Checklist

- [x] ~I adjusted the README (if needed)~ (not needed)
- [x] ~For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)~ (not a new feature)
