### PR TITLE
Add Corsair Virtuoso Max Wireless support

### DIFF
--- a/lib/devices/corsair_void_v2w.hpp
+++ b/lib/devices/corsair_void_v2w.hpp
@@ -27,7 +27,7 @@ namespace headsetcontrol {
  */
 class CorsairVoidV2W : public CorsairDevice {
 public:
-    static constexpr std::array<uint16_t, 1> SUPPORTED_PRODUCT_IDS { 0x2a08 };
+    static constexpr std::array<uint16_t, 2> SUPPORTED_PRODUCT_IDS { 0x2a08, 0x2a02 };
 
     std::vector<uint16_t> getProductIds() const override
     {


### PR DESCRIPTION
## Summary

- Adds product ID `0x2a02` (Corsair Virtuoso Max Wireless Gaming Receiver) to the `CorsairVoidV2W` driver
- The Virtuoso Max receiver uses the same V2 protocol on interface 4 (usage page `0xff42`)

## Tested Features

| Feature | Status |
|---------|--------|
| Battery | Working (reports 0-100%) |
| Sidetone | Working (0-128 range) |

## Device Info

```
Bus 003 Device 027: ID 1b1c:2a00 Corsair CORSAIR VIRTUOSO MAX WIRELESS Gaming Headset
Bus 003 Device 029: ID 1b1c:2a02 Corsair CORSAIR VIRTUOSO MAX WIRELESS Gaming Receiver
```

Only the receiver (`0x2a02`) is needed — it handles all HID control communication with the headset over the wireless link.

## Test Environment

- Linux 6.17.0, Ubuntu 24.04
- Wireless (2.4GHz dongle) connection
- HIDAPI 0.14.0