### PR TITLE
Add HeadsetControl-GUI to the Linux GUI applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ headsetcontrol --test-device -b
 - [headset-charge-indicator](https://github.com/centic9/headset-charge-indicator/) - System tray with controls (Python)
 - [headset-battery-indicator](https://github.com/ruflas/headset-battery-indicator) - Tray icon with ChatMix, Sidetone controls (Python/Qt)
 - [headsetcontrol-notificationd](https://github.com/Manawyrm/headsetcontrol-notificationd) - Battery notifications (PHP)
+- [HeadsetControl-GUI](https://github.com/paradox-ng/HeadsetControl-GUI) - System tray and window with controls; x86-64 and ARM64 builds (Python/Qt6)
 
 ### macOS
 - [HeadsetControl-MacOSTray](https://github.com/ChrisLauinger77/HeadsetControl-MacOSTray) - Menu bar app (macOS 14+)


### PR DESCRIPTION
### Changes made

Added my GUI, [HeadsetControl-GUI](https://github.com/paradox-ng/HeadsetControl-GUI), to the **Linux** section of the GUI Applications list. It's a Qt6/PySide6 app with a system-tray icon and a control window for sidetone, lights, battery and notification sounds, driven by `headsetcontrol`'s JSON output. Prebuilt AppImages are provided for x86-64 and ARM64.

This is a docs-only change: a single line added to the README list. No code changes.

### Checklist

- [x] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)


Related to: https://github.com/Sapd/HeadsetControl/issues/532