### PR TITLE
Add support for Audeze Maxwell 2 Xbox version (PID 0x4b28)

### DIFF
--- a/lib/devices/audeze_maxwell2.hpp
+++ b/lib/devices/audeze_maxwell2.hpp
@@ -30,8 +30,9 @@ namespace headsetcontrol {
  */
 class AudezeMaxwell2 : public HIDDevice {
 public:
-    static constexpr std::array<uint16_t, 1> SUPPORTED_PRODUCT_IDS {
-        0x4b29 // Maxwell 2 (PlayStation/PC version)
+    static constexpr std::array<uint16_t, 2> SUPPORTED_PRODUCT_IDS {
+        0x4b29, // Maxwell 2 (PlayStation/PC version)
+        0x4b28  // Maxwell 2 (Xbox version)
     };
 
     static constexpr int MSG_SIZE  = 62;


### PR DESCRIPTION
### Changes made
 
This adds support for the **Xbox variant of the Audeze Maxwell 2** by registering its
product ID `0x4b28` alongside the existing PlayStation/PC variant (`0x4b29`) in
`lib/devices/audeze_maxwell2.hpp`.
 
This mirrors how the original Maxwell supports both of its variants
(`0x4b19` PlayStation / `0x4b18` Xbox) — the HID configuration protocol is identical,
only the product ID differs.
 
**Device:**
 
```
Bus 001 Device 009: ID 3329:4b28 Audeze LLC Audeze Maxwell XBOX Dongle
```
 
**Tested on hardware** (Ubuntu, Audeze Maxwell 2 Xbox + USB dongle):
 
- Device detection ✔ (reported as "Audeze Maxwell 2", `id_product: 0x4b28`)
- Battery status ✔ (reported 92%)
- Sidetone ✔ (audibly changes with `-s 0` / `-s 25`)
- `--output json` reports all 7 capabilities (sidetone, battery, inactive time,
  chatmix, voice prompts, equalizer preset, microphone noise filter)
  and 10 equalizer presets ✔
<details>
<summary>Full <code>--output json</code> from the device</summary>
```json
{
  "name": "HeadsetControl",
  "version": "continuous-52-gfe086cd-modified",
  "api_version": "1.4",
  "hidapi_version": "0.14.0",
  "device_count": 1,
  "devices": [
    {
      "status": "success",
      "device": "Audeze Maxwell 2",
      "vendor": "Audeze LLC",
      "product": "Audeze Maxwell XBOX Dongle",
      "id_vendor": "0x3329",
      "id_product": "0x4b28",
      "capabilities": [
        "CAP_SIDETONE",
        "CAP_BATTERY_STATUS",
        "CAP_INACTIVE_TIME",
        "CAP_CHATMIX_STATUS",
        "CAP_VOICE_PROMPTS",
        "CAP_EQUALIZER_PRESET",
        "CAP_NOISE_FILTER"
      ],
      "battery": {
        "status": "BATTERY_AVAILABLE",
        "level": 92
      },
      "equalizer_presets_count": 10,
      "chatmix": 64
    }
  ]
}
```
 
</details>
### Checklist
 
- [x] I adjusted the README (if needed) — *no change needed: the "Audeze Maxwell 2"
  row already lists "All" as supported platforms; this PR makes that fully accurate
  for the Xbox variant*
- [x] For new features in HeadsetControl: I discussed it beforehand in Issues or
  Discussions and adhered to the wiki — *not applicable: this is not a new feature,
  only an additional product ID for an already supported device (analogous to the
  Maxwell 1 Xbox dongle `0x4b18`)*