### PR TITLE
packaging: RPM spec for Fedora COPR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@
 *.md text eol=lf
 *.txt text eol=lf
 CMakeLists.txt text eol=lf
+headsetcontrol.spec export-ignore

--- a/headsetcontrol.spec
+++ b/headsetcontrol.spec
@@ -1,0 +1,48 @@
+Name:           headsetcontrol
+Version:        4.0.0
+Release:        1%{?dist}
+Summary:        Control features of USB gaming headsets
+
+License:        GPL-3.0-only
+URL:            https://github.com/Sapd/HeadsetControl
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  hidapi-devel
+BuildRequires:  pkgconfig
+BuildRequires:  systemd-rpm-macros
+
+%description
+HeadsetControl is a tool to control USB-connected gaming headsets: sidetone,
+battery status, LEDs, inactive-time auto-shutoff, chatmix, equalizer presets
+and more, for a wide range of Logitech, SteelSeries, Corsair, HyperX, Roccat
+and Audeze devices. On Linux it installs udev rules so the headsets are
+accessible without root privileges.
+
+%prep
+%autosetup -n HeadsetControl-%{version}
+# Release tarballs have no git metadata; inject the version so the binary does
+# not report 0.0.0-unknown. (From the next release, -DHEADSETCONTROL_VERSION
+# handles this and this sed can be dropped.)
+sed -i 's/git describe --tags --dirty=-modified/echo %{version}/' CMakeLists.txt
+
+%build
+%cmake -DHEADSETCONTROL_VERSION=%{version}
+%cmake_build
+
+%install
+%cmake_install
+# CLI package: drop the static library and dev headers
+rm -f %{buildroot}%{_prefix}/lib/libheadsetcontrol*
+rm -rf %{buildroot}%{_includedir}/headsetcontrol
+
+%files
+%license license
+%doc README.md
+%{_bindir}/headsetcontrol
+%{_udevrulesdir}/70-headsets.rules
+
+%changelog
+* Thu Jul 23 2026 Denis Arnst <git@sapd.eu> - 4.0.0-1
+- Initial COPR packaging


### PR DESCRIPTION
Adds `headsetcontrol.spec` so the project can be built for a **Fedora COPR** (`dnf`).

**Validated in a `fedora:latest` container** (full `rpmbuild`):
- ships `/usr/bin/headsetcontrol` + `/usr/lib/udev/rules.d/70-headsets.rules`, static lib/headers excluded
- reports version **4.0.0** (release tarballs lack git metadata, so `%prep` injects it via sed until #543's `-DHEADSETCONTROL_VERSION` is in a release)
- deps auto-detected (libhidapi-hidraw), `License: GPL-3.0-only`, lintian/rpmlint-clean shape

Note: targets **Fedora** chroots — RHEL/EPEL 9 ships GCC 11, too old for this project's C++20/`std::format` (needs GCC 13+). `export-ignore` keeps the spec out of source tarballs.