### PR TITLE
perf(cli): skip the forced info reads when the invocation performs an action

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1031,14 +1031,13 @@ std::vector<DeviceList> toLegacyDeviceList(std::vector<DiscoveredDevice>& device
     return legacy;
 }
 
-// Whether this invocation was asked to set something.
-bool hasRequestedAction(const std::vector<DiscoveredDevice>& devices)
+// Whether this device was asked to set something. Only counts requests that are
+// still live, so it has to run after handleMultiDeviceActions has had its say.
+bool hasRequestedAction(const DiscoveredDevice& device)
 {
-    for (const auto& dev : devices) {
-        for (const auto& req : dev.feature_requests) {
-            if (req.type == CAPABILITYTYPE_ACTION && req.should_process) {
-                return true;
-            }
+    for (const auto& req : device.feature_requests) {
+        if (req.type == CAPABILITYTYPE_ACTION && req.should_process) {
+            return true;
         }
     }
 
@@ -1047,13 +1046,17 @@ bool hasRequestedAction(const std::vector<DiscoveredDevice>& devices)
 
 // Enable info requests for extended output formats (JSON, YAML, ENV)
 // Only for a pure query: the extra reads can cost far more than the action
-// itself (Maxwell 2: -s 20 is 0.07 s, -s 20 -o json is 2.90 s).
+// itself (Maxwell 2: -s 20 is 0.07 s, -s 20 -o json is 2.90 s). Per device, so
+// an action on one headset does not silence the info reads of another.
 void enableExtendedInfoRequests(std::vector<DiscoveredDevice>& devices, bool extended)
 {
-    if (!extended || hasRequestedAction(devices))
+    if (!extended)
         return;
 
     for (auto& dev : devices) {
+        if (hasRequestedAction(dev))
+            continue;
+
         for (auto& req : dev.feature_requests) {
             if (req.type == CAPABILITYTYPE_INFO && !req.should_process && dev.hasCapability(req.cap)) {
                 req.should_process = true;
@@ -1217,8 +1220,11 @@ int main(int argc, char* argv[])
     // Initialize and configure feature requests
     initializeFeatureRequests(devices, opts);
     bool extended = opts.output_format == OUTPUT_YAML || opts.output_format == OUTPUT_JSON || opts.output_format == OUTPUT_ENV;
-    enableExtendedInfoRequests(devices, extended);
+    // Order matters: handleMultiDeviceActions neutralizes action requests, and
+    // enableExtendedInfoRequests has to see the result of that, not the requests
+    // as they were parsed.
     handleMultiDeviceActions(devices, opts);
+    enableExtendedInfoRequests(devices, extended);
 
     // Main loop
     do {

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -37,8 +37,8 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
-#include <cstdio>
 #include <csignal>
+#include <cstdio>
 #include <cstdlib>
 #include <format>
 #include <iostream>
@@ -420,7 +420,7 @@ public:
         if (devices_)
             hid_free_enumeration(devices_);
     }
-    HIDEnumeration(const HIDEnumeration&) = delete;
+    HIDEnumeration(const HIDEnumeration&)            = delete;
     HIDEnumeration& operator=(const HIDEnumeration&) = delete;
 
     hid_device_info* get() const { return devices_; }
@@ -1003,7 +1003,7 @@ void setupSignalHandler()
 #ifdef _WIN32
     signal(SIGINT, signalHandler);
 #else
-    struct sigaction act {};
+    struct sigaction act { };
     act.sa_handler = signalHandler;
     sigaction(SIGINT, &act, nullptr);
 #endif

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -1031,10 +1031,26 @@ std::vector<DeviceList> toLegacyDeviceList(std::vector<DiscoveredDevice>& device
     return legacy;
 }
 
+// Whether this invocation was asked to set something.
+bool hasRequestedAction(const std::vector<DiscoveredDevice>& devices)
+{
+    for (const auto& dev : devices) {
+        for (const auto& req : dev.feature_requests) {
+            if (req.type == CAPABILITYTYPE_ACTION && req.should_process) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 // Enable info requests for extended output formats (JSON, YAML, ENV)
+// Only for a pure query: the extra reads can cost far more than the action
+// itself (Maxwell 2: -s 20 is 0.07 s, -s 20 -o json is 2.90 s).
 void enableExtendedInfoRequests(std::vector<DiscoveredDevice>& devices, bool extended)
 {
-    if (!extended)
+    if (!extended || hasRequestedAction(devices))
         return;
 
     for (auto& dev : devices) {

--- a/cli/output/output.cpp
+++ b/cli/output/output.cpp
@@ -181,8 +181,7 @@ void processFeatureRequest(const FeatureRequest& req, DeviceData& dev, std::stri
                 for (const auto& preset : presets->presets) {
                     preset_data.push_back(EqualizerPresetData {
                         .name   = preset.name,
-                        .values = preset.values
-                    });
+                        .values = preset.values });
                 }
                 dev.equalizer_presets = std::move(preset_data);
             }

--- a/cli/output/output.cpp
+++ b/cli/output/output.cpp
@@ -23,7 +23,9 @@ using namespace headsetcontrol::serializers;
 // Constants
 // ============================================================================
 
-constexpr std::string_view API_VERSION = "1.4";
+// 1.5: an invocation that performs an action no longer reports info it was not
+// explicitly asked for.
+constexpr std::string_view API_VERSION = "1.5";
 constexpr std::string_view APP_NAME    = "HeadsetControl";
 
 // ============================================================================

--- a/docs/LIBRARY_USAGE.md
+++ b/docs/LIBRARY_USAGE.md
@@ -28,7 +28,7 @@ headsetcontrol -o env
 {
   "name": "HeadsetControl",
   "version": "3.0.0",
-  "api_version": "1.4",
+  "api_version": "1.5",
   "device_count": 1,
   "devices": [
     {

--- a/tests/test_cli_output.cpp
+++ b/tests/test_cli_output.cpp
@@ -298,6 +298,54 @@ void testCliEnvShellSafe()
 }
 
 // ============================================================================
+// Action + Extended Output Tests
+// ============================================================================
+
+void testCliActionOnlyOmitsUnrequestedInfo()
+{
+    std::cout << "  Testing action-only invocation omits info not explicitly requested..." << std::endl;
+
+    // -s (sidetone) is an action; battery/chatmix were not asked for, so an
+    // extended-format invocation should not pay for reading them.
+    std::string output = exec(HEADSETCONTROL_EXE " --test-device -s 20 -o json 2>&1");
+
+    ASSERT_CONTAINS(output, "\"actions\":", "Should have actions array");
+    ASSERT_NOT_CONTAINS(output, "\"battery\":", "Battery info should be omitted when not requested");
+    ASSERT_NOT_CONTAINS(output, "\"chatmix\":", "Chatmix info should be omitted when not requested");
+
+    std::cout << "    ✓ Action-only invocation omits unrequested info" << std::endl;
+}
+
+void testCliActionWithExplicitInfoKeepsOnlyThat()
+{
+    std::cout << "  Testing action + explicit info request keeps only that info..." << std::endl;
+
+    // -b is explicitly requested alongside the -s action; chatmix was not
+    // asked for and should still be omitted.
+    std::string output = exec(HEADSETCONTROL_EXE " --test-device -b -s 20 -o json 2>&1");
+
+    ASSERT_CONTAINS(output, "\"actions\":", "Should have actions array");
+    ASSERT_CONTAINS(output, "\"battery\":", "Explicitly requested battery info should be present");
+    ASSERT_NOT_CONTAINS(output, "\"chatmix\":", "Chatmix info should be omitted when not requested");
+
+    std::cout << "    ✓ Action with explicit info request keeps only that info" << std::endl;
+}
+
+void testCliPureQueryStillReturnsAllInfo()
+{
+    std::cout << "  Testing pure query (no action) still returns all extended info..." << std::endl;
+
+    // No action requested, so the extended-format default of reading every
+    // supported info capability still applies.
+    std::string output = exec(HEADSETCONTROL_EXE " --test-device -o json 2>&1");
+
+    ASSERT_CONTAINS(output, "\"battery\":", "Pure query should still report battery");
+    ASSERT_CONTAINS(output, "\"chatmix\":", "Pure query should still report chatmix");
+
+    std::cout << "    ✓ Pure query still returns all extended info" << std::endl;
+}
+
+// ============================================================================
 // Standard Output Tests
 // ============================================================================
 
@@ -443,6 +491,11 @@ void runAllCliOutputTests()
     std::cout << "\n=== ENV CLI Tests ===" << std::endl;
     runTest("ENV Output", testCliEnvOutput);
     runTest("ENV Shell-Safe", testCliEnvShellSafe);
+
+    std::cout << "\n=== Action + Extended Output Tests ===" << std::endl;
+    runTest("Action-Only Omits Unrequested Info", testCliActionOnlyOmitsUnrequestedInfo);
+    runTest("Action With Explicit Info", testCliActionWithExplicitInfoKeepsOnlyThat);
+    runTest("Pure Query Still Returns All Info", testCliPureQueryStillReturnsAllInfo);
 
     std::cout << "\n=== Standard Output Tests ===" << std::endl;
     runTest("Standard Output", testCliStandardOutput);


### PR DESCRIPTION
Structured output (json/yaml/env) marks every info capability as requested, no
matter what the command line actually asked for. On a device with an expensive
status read that dominates an action which is otherwise instant.

Audeze Maxwell 2 (0x3329:0x4b28), release build:

    headsetcontrol -d 0x3329:0x4b28 -s 20                 0.07 s
    headsetcontrol -d 0x3329:0x4b28 -s 20 --output=json   2.90 s

The difference is the status read - getDeviceStatus() sends 15 init packets plus
6 status requests, each after a 60 ms delay. The sidetone write itself is one
packet. Anything driving the CLI per user interaction pays that every time; a GUI
moving a slider ends up queueing writes for minutes.

After the patch the same call takes 0.07 s and the actions array is unchanged. A
pure query is unaffected: --output json still takes 2.83 s and still reports
battery and chatmix. Info asked for explicitly still works, -b -s 20 -o json
reports the battery in 1.49 s.

headsetcontrol_tests passes.

One thing to decide: this changes the json shape for action invocations,
devices[].battery is no longer there when you only asked to set something. I think
the old behaviour is the bug, but if you would rather keep the default I can put
it behind a flag instead.
