### PR TITLE
perf(audeze): answer every info capability from one status read

### DIFF
--- a/lib/devices/audeze_maxwell2.hpp
+++ b/lib/devices/audeze_maxwell2.hpp
@@ -33,7 +33,7 @@ class AudezeMaxwell2 : public HIDDevice {
 public:
     static constexpr std::array<uint16_t, 2> SUPPORTED_PRODUCT_IDS {
         0x4b29, // Maxwell 2 (PlayStation/PC version)
-        0x4b28  // Maxwell 2 (Xbox version)
+        0x4b28 // Maxwell 2 (Xbox version)
     };
 
     static constexpr int MSG_SIZE  = 62;

--- a/lib/devices/audeze_maxwell2.hpp
+++ b/lib/devices/audeze_maxwell2.hpp
@@ -4,7 +4,6 @@
 #include "hid_device.hpp"
 #include <array>
 #include <chrono>
-#include <mutex>
 #include <optional>
 #include <string_view>
 #include <thread>
@@ -222,19 +221,22 @@ private:
         return status;
     }
 
+    static constexpr auto STATUS_REUSE_WINDOW = std::chrono::milliseconds(500);
+
     /**
      * @brief Reuse one status read for every info capability.
      *
      * getDeviceStatus() costs 21 packets at 60 ms and already returns everything,
      * but each getter called it again. Keyed on the handle since one instance
-     * serves every attached Maxwell 2, and locked since that instance is shared.
+     * serves every attached Maxwell 2.
+     *
+     * The reused status also carries sidetone, equalizer and noise filter, so
+     * every setter that writes one of those calls invalidateStatus(). A getter
+     * built on top of this must keep that list in sync, otherwise a set followed
+     * by a get inside the window returns the value from before the write.
      */
-    static constexpr auto STATUS_REUSE_WINDOW = std::chrono::milliseconds(500);
-
     Result<MaxwellStatus> statusFor(hid_device* device_handle)
     {
-        const std::lock_guard<std::mutex> guard(status_mutex_);
-
         if (last_status_ && last_handle_ == device_handle
             && std::chrono::steady_clock::now() - read_at_ < STATUS_REUSE_WINDOW) {
             return *last_status_;
@@ -254,7 +256,12 @@ private:
         return *status;
     }
 
-    std::mutex status_mutex_;
+    // Drop the reused status after a write that changes one of its fields.
+    void invalidateStatus()
+    {
+        last_status_.reset();
+    }
+
     hid_device* last_handle_ = nullptr;
     std::optional<MaxwellStatus> last_status_;
     std::chrono::steady_clock::time_point read_at_ {};
@@ -273,6 +280,8 @@ public:
 
     Result<SidetoneResult> setSidetone(hid_device* device_handle, uint8_t level) override
     {
+        invalidateStatus();
+
         // Maxwell range: 0 to 31
         uint8_t mapped = map<uint8_t>(level, 0, 128, 0, 31);
 
@@ -392,6 +401,8 @@ public:
 
     Result<EqualizerPresetResult> setEqualizerPreset(hid_device* device_handle, uint8_t preset) override
     {
+        invalidateStatus();
+
         // Maxwell supports presets 0-9 (mapped to device presets 1-10)
         // 0-5 are built-in presets, 6-9 are custom presets
         if (preset >= EQUALIZER_PRESETS_COUNT) {
@@ -413,6 +424,8 @@ public:
 
     Result<NoiseFilterResult> setNoiseFilter(hid_device* device_handle, uint8_t level) override
     {
+        invalidateStatus();
+
         // Maxwell 2 has three levels for the noise filter: high, low, and
         // off (2,1 and 0)
         if (level > 2) {

--- a/lib/devices/audeze_maxwell2.hpp
+++ b/lib/devices/audeze_maxwell2.hpp
@@ -4,6 +4,8 @@
 #include "hid_device.hpp"
 #include <array>
 #include <chrono>
+#include <mutex>
+#include <optional>
 #include <string_view>
 #include <thread>
 
@@ -220,11 +222,48 @@ private:
         return status;
     }
 
+    /**
+     * @brief Reuse one status read for every info capability.
+     *
+     * getDeviceStatus() costs 21 packets at 60 ms and already returns everything,
+     * but each getter called it again. Keyed on the handle since one instance
+     * serves every attached Maxwell 2, and locked since that instance is shared.
+     */
+    static constexpr auto STATUS_REUSE_WINDOW = std::chrono::milliseconds(500);
+
+    Result<MaxwellStatus> statusFor(hid_device* device_handle)
+    {
+        const std::lock_guard<std::mutex> guard(status_mutex_);
+
+        if (last_status_ && last_handle_ == device_handle
+            && std::chrono::steady_clock::now() - read_at_ < STATUS_REUSE_WINDOW) {
+            return *last_status_;
+        }
+
+        auto status = getDeviceStatus(device_handle);
+        if (!status) {
+            return status.error();
+        }
+
+        last_handle_ = device_handle;
+        last_status_ = *status;
+        // After the read, not before: it takes ~1.4 s, so a timestamp taken going
+        // in would already have expired.
+        read_at_ = std::chrono::steady_clock::now();
+
+        return *status;
+    }
+
+    std::mutex status_mutex_;
+    hid_device* last_handle_ = nullptr;
+    std::optional<MaxwellStatus> last_status_;
+    std::chrono::steady_clock::time_point read_at_ {};
+
 public:
     // Rich Results V2 API
     Result<BatteryResult> getBattery(hid_device* device_handle) override
     {
-        auto status_result = getDeviceStatus(device_handle);
+        auto status_result = statusFor(device_handle);
         if (!status_result) {
             return status_result.error();
         }
@@ -332,7 +371,7 @@ public:
 
     Result<ChatmixResult> getChatmix(hid_device* device_handle) override
     {
-        auto status_result = getDeviceStatus(device_handle);
+        auto status_result = statusFor(device_handle);
         if (!status_result) {
             return status_result.error();
         }

--- a/lib/devices/audeze_maxwell2.hpp
+++ b/lib/devices/audeze_maxwell2.hpp
@@ -401,13 +401,13 @@ public:
 
     Result<EqualizerPresetResult> setEqualizerPreset(hid_device* device_handle, uint8_t preset) override
     {
-        invalidateStatus();
-
         // Maxwell supports presets 0-9 (mapped to device presets 1-10)
         // 0-5 are built-in presets, 6-9 are custom presets
         if (preset >= EQUALIZER_PRESETS_COUNT) {
             return DeviceError::invalidParameter("Device only supports presets 0-9");
         }
+
+        invalidateStatus();
 
         // Device uses 1-10 range internally
         uint8_t device_preset = preset + 1;
@@ -424,13 +424,14 @@ public:
 
     Result<NoiseFilterResult> setNoiseFilter(hid_device* device_handle, uint8_t level) override
     {
-        invalidateStatus();
-
         // Maxwell 2 has three levels for the noise filter: high, low, and
         // off (2,1 and 0)
         if (level > 2) {
             return DeviceError::invalidParameter("Noise filter level must be 0, 1, or 2");
         }
+
+        invalidateStatus();
+
         std::array<uint8_t, MSG_SIZE> cmd { 0x06, 0x09, 0x80, 0x05, 0x5A, 0x05, 0x00, 0x00, 0x09, 0x24, 0x00, level };
 
         auto result = sendGetInputReport(device_handle, cmd);


### PR DESCRIPTION
getDeviceStatus() sends 15 init packets plus 6 status requests, each after a 60 ms
delay, and returns battery, chatmix, sidetone, equalizer and noise filter
together. But getBattery() and getChatmix() each call it, so asking for both pays
twice for one set of numbers.

Audeze Maxwell 2 (0x3329:0x4b28), release build:

    headsetcontrol -d 0x3329:0x4b28 -b -o json      1.48 s
    headsetcontrol -d 0x3329:0x4b28 -b -m -o json   2.83 s

With the status reused for 500 ms the second one drops to 1.41 s. The window is
much shorter than the 1.4 s read it saves, so nothing gets a value staler than its
own read would have produced. Reading both from one pass also makes them a
coherent snapshot instead of two readings 1.4 s apart.

Keyed on the device handle since DeviceRegistry keeps one instance per device
class, and mutex-guarded since that instance is shared - it is the only mutable
state in the class. Happy to drop the lock if you consider concurrent calls out of
scope.

headsetcontrol_tests passes.

Unrelated but visible if you test this: status reads on this device fail
intermittently on master too - five consecutive -b -m -o json runs gave
battery = -1, 74, -1, -1, 74 - so a flaky reading is not a regression from this
patch.

Independent of #549, different file and different cause; either can go in without
the other.
