### PR TITLE
gitattributes: normalise all text files to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,14 @@
+# Normalise every text file to LF, in the index and in the working tree.
+# This must stay the first rule: git applies the last matching pattern per
+# attribute, so the binary declarations below have to be able to override it.
+#
+# Without a catch-all, files not matched by an extension rule keep whatever
+# line endings the cloning client produces. Git for Windows defaults to
+# core.autocrlf=true, so such files land as CRLF, and MSYS2 git (which defaults
+# to false) then reports the whole tree as modified -- which made the MinGW CI
+# build stamp every binary as "<version>-modified".
+* text=auto eol=lf
+
 # Binary files - don't check for whitespace or diff
 *.png binary
 *.ico binary
@@ -6,17 +17,6 @@
 *.gif binary
 *.pdf binary
 
-# Ensure consistent line endings
-*.c text eol=lf
-*.cpp text eol=lf
-*.h text eol=lf
-*.hpp text eol=lf
-*.cmake text eol=lf
-*.yml text eol=lf
-*.yaml text eol=lf
-*.json text eol=lf
-*.md text eol=lf
-*.txt text eol=lf
-CMakeLists.txt text eol=lf
+# Keep packaging sources out of `git archive` tarballs
 debian/ export-ignore
 headsetcontrol.spec export-ignore


### PR DESCRIPTION
The MinGW CI build stamped every Windows binary as "<version>-modified" even on a pristine checkout. Cause, reproduced on a Windows 11 + MSYS2 box:

  Git for Windows  core.autocrlf = true    (its own system gitconfig)
  MSYS2 git        core.autocrlf = unset -> false

actions/checkout runs under Git for Windows and writes CRLF; the build then reads the tree with MSYS2 git, which expects LF. Files covered by an extension rule were fine, but 14 were not matched by any pattern and showed up permanently modified:

  i/lf    w/crlf  attr/     .clang-format
  i/lf    w/crlf  attr/     debian/rules

Note the empty attr/ column. The gaps were dotfiles, extensionless files, debian/*, *.rc, *.spec, *.sh, and lib/version.h.in (which *.h does not match). Listing extensions cannot close this class of gap -- the next unlisted file type reopens it -- so replace the list with a catch-all.

The catch-all must come first, because git applies the last matching pattern per attribute and the binary declarations need to override it. Verified: assets/headsetcontrol.{ico,png} still resolve to text=unset binary=set, and `git add --renormalize .` rewrites no blob, since every file was already LF in the index.

Besides CI, this also fixes the same false-dirty state for anyone developing on Windows.
