### PR TITLE
Add missing Arctis Nova 7P Gen2 PID

### DIFF
--- a/lib/devices/steelseries_arctis_nova_7p.hpp
+++ b/lib/devices/steelseries_arctis_nova_7p.hpp
@@ -21,6 +21,7 @@ public:
         return {
             0x220a, // Arctis Nova 7P (discrete battery: 0-4, before Jan. 2026 update)
             0x22a7 // Arctis Nova 7P V2 (percentage battery: 0-100, after Jan. 2026 update)
+            0x2298 // Arctis Nova 7P V2 (percentage battery: 0-100)
         };
     }
 


### PR DESCRIPTION
### Changes made

Added missing PID for the Arctis Nova 7P Gen 2. Spotted while trying to figure out why my headset isn't being detected by HeadsetControl.

I did some basic testing of the features that are listed as supported and everything seems to work.

Related: https://github.com/loteran/Arctis-Sound-Manager/issues/146

### Checklist

- [x] I adjusted the README (if needed)
- [x] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
