### PR TITLE
fix: enable Windows support for Arctis Nova 3P/3X via output reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 | SteelSeries Arctis Nova 7P | All |   | x |   |   | x |   |   |   | x | x |   | x | x | x | x | x |   |
 | SteelSeries Arctis 7+ | All | x | x |   |   | x | x |   |   | x | x |   |   |   |   |   |   |   |
 | SteelSeries Arctis Nova Pro Wireless | All | x | x |   | x | x |   |   |   | x | x |   |   |   |   |   |   |   |
-| SteelSeries Arctis Nova 3P Wireless | L/M | x | x |   |   | x |   |   |   | x | x | x |   | x |   |   |   |   |
+| SteelSeries Arctis Nova 3P Wireless | All | x | x |   |   | x |   |   |   | x | x | x |   | x |   |   |   |   |
 | SteelSeries Arctis Buds | All |  | x |   |   |  |   |   |   |  |  |  |   |  |   |   |   |   |
 | HyperX Cloud Alpha Wireless | All | x | x |   |   | x |   | x |   |   |   |   |   |   |   |   |   |   |
 | HyperX Cloud Flight Wireless | All |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |

--- a/lib/devices/steelseries_arctis_nova_3p_wireless.hpp
+++ b/lib/devices/steelseries_arctis_nova_3p_wireless.hpp
@@ -19,8 +19,6 @@ namespace headsetcontrol {
  * - Battery status
  * - Equalizer (10 bands)
  * - Parametric equalizer (ADVANCED!)
- *
- * NOTE: Windows support has HID packet length issues
  */
 class SteelSeriesArctisNova3PWireless : public protocols::SteelSeriesNovaDevice<SteelSeriesArctisNova3PWireless> {
 public:
@@ -106,12 +104,6 @@ public:
         return { .usagepage = 0xffc0, .usageid = 0x1, .interface_id = 3 };
     }
 
-    constexpr uint8_t getSupportedPlatforms() const override
-    {
-        // Windows has HID packet length issues
-        return PLATFORM_LINUX | PLATFORM_MACOS;
-    }
-
     std::optional<EqualizerInfo> getEqualizerInfo() const override
     {
         return EqualizerInfo {
@@ -167,36 +159,41 @@ public:
     // Helper: save state
     Result<void> saveStateNova3P(hid_device* device_handle) const
     {
-        std::array<uint8_t, 1> cmd { 0x09 };
-        return sendFeatureReport(device_handle, cmd, MSG_SIZE);
+        std::array<uint8_t, 2> cmd { 0x00, 0x09 };
+        return writeHID(device_handle, cmd, MSG_SIZE);
     }
 
     // Rich Results V2 API
     Result<BatteryResult> getBattery(hid_device* device_handle) override
     {
-        std::array<uint8_t, 1> request { 0xb0 };
-        if (auto result = sendFeatureReport(device_handle, request, MSG_SIZE); !result) {
-            return result.error();
+        auto status_result = readDeviceStatus(device_handle);
+        if (!status_result) {
+            return status_result.error();
         }
 
-        std::array<uint8_t, 4> response {};
-        auto read_result = readHIDTimeout(device_handle, response, hsc_device_timeout);
-
-        if (!read_result) {
-            return read_result.error();
+        auto& data = *status_result;
+        if (data.size() < 5) {
+            return DeviceError::protocolError("Response too short");
         }
 
-        constexpr uint8_t HEADSET_OFFLINE = 0x02;
-        if (response[1] == HEADSET_OFFLINE) {
+        constexpr uint8_t HEADSET_OFFLINE  = 0x02;
+        constexpr uint8_t HEADSET_CHARGING = 0x01;
+
+        if (data[1] == HEADSET_OFFLINE) {
             return DeviceError::deviceOffline("Headset not connected");
         }
 
-        int level = map(response[3], 0, 100, 0, 100);
+        enum battery_status status = BATTERY_AVAILABLE;
+        if (data[4] == HEADSET_CHARGING) {
+            status = BATTERY_CHARGING;
+        }
+
+        int level = data[3]; // Already in percentage
 
         return BatteryResult {
             .level_percent = level,
-            .status        = BATTERY_AVAILABLE,
-            .raw_data      = std::vector<uint8_t> { response.begin(), response.end() }
+            .status        = status,
+            .raw_data      = data
         };
     }
 
@@ -204,8 +201,8 @@ public:
     {
         uint8_t mapped = map<uint8_t>(level, 0, 128, 0, 0xa);
 
-        std::array<uint8_t, 2> cmd { 0x39, mapped };
-        if (auto result = sendFeatureReport(device_handle, cmd, MSG_SIZE); !result) {
+        std::array<uint8_t, 3> cmd { 0x00, 0x39, mapped };
+        if (auto result = writeHID(device_handle, cmd, MSG_SIZE); !result) {
             return result.error();
         }
 
@@ -246,8 +243,8 @@ public:
         else
             minutes = 0; // Never turn off
 
-        std::array<uint8_t, 2> cmd { 0xa3, minutes };
-        if (auto result = sendFeatureReport(device_handle, cmd, MSG_SIZE); !result) {
+        std::array<uint8_t, 3> cmd { 0x00, 0xa3, minutes };
+        if (auto result = writeHID(device_handle, cmd, MSG_SIZE); !result) {
             return result.error();
         }
 
@@ -266,8 +263,8 @@ public:
     {
         uint8_t mapped = map<uint8_t>(volume, 0, 128, 0, 0x0e);
 
-        std::array<uint8_t, 2> cmd { 0x37, mapped };
-        if (auto result = sendFeatureReport(device_handle, cmd, MSG_SIZE); !result) {
+        std::array<uint8_t, 3> cmd { 0x00, 0x37, mapped };
+        if (auto result = writeHID(device_handle, cmd, MSG_SIZE); !result) {
             return result.error();
         }
 
@@ -321,7 +318,8 @@ public:
         }
 
         std::array<uint8_t, MSG_SIZE> data {};
-        data[0] = 0x33;
+        data[0] = 0x00;
+        data[1] = 0x33;
 
         for (int i = 0; i < EQUALIZER_BANDS; i++) {
             float gain_value = settings.bands[i];
@@ -331,16 +329,16 @@ public:
 
             // Each band: 2 bytes frequency (LE), 1 byte filter type, 1 byte gain, 2 bytes Q-factor (LE)
             uint16_t freq       = BAND_FREQUENCIES[i];
-            data[1 + 6 * i]     = freq & 0xFF;
-            data[1 + 6 * i + 1] = (freq >> 8) & 0xFF;
-            data[1 + 6 * i + 2] = 0x01; // Peaking filter
-            data[1 + 6 * i + 3] = encodeGain(gain_value);
+            data[2 + 6 * i]     = freq & 0xFF;
+            data[2 + 6 * i + 1] = (freq >> 8) & 0xFF;
+            data[2 + 6 * i + 2] = 0x01; // Peaking filter
+            data[2 + 6 * i + 3] = encodeGain(gain_value);
             // Default Q-factor: 1.414 * 1000 = 1414 = 0x0586
-            data[1 + 6 * i + 4] = 0x86;
-            data[1 + 6 * i + 5] = 0x05;
+            data[2 + 6 * i + 4] = 0x86;
+            data[2 + 6 * i + 5] = 0x05;
         }
 
-        if (auto result = sendFeatureReport(device_handle, data, MSG_SIZE); !result) {
+        if (auto result = writeHID(device_handle, data, MSG_SIZE); !result) {
             return result.error();
         }
 
@@ -358,7 +356,8 @@ public:
         }
 
         std::array<uint8_t, MSG_SIZE> data {};
-        data[0] = 0x33;
+        data[0] = 0x00;
+        data[1] = 0x33;
 
         // Write provided bands
         for (int i = 0; i < settings.size(); i++) {
@@ -383,40 +382,40 @@ public:
 
             // Write frequency (LE)
             uint16_t freq       = static_cast<uint16_t>(band.frequency);
-            data[1 + 6 * i]     = freq & 0xFF;
-            data[1 + 6 * i + 1] = (freq >> 8) & 0xFF;
+            data[2 + 6 * i]     = freq & 0xFF;
+            data[2 + 6 * i + 1] = (freq >> 8) & 0xFF;
 
             // Write filter type
-            data[1 + 6 * i + 2] = getFilterByte(band.type);
+            data[2 + 6 * i + 2] = getFilterByte(band.type);
 
             // Write gain (two's complement for negative)
-            data[1 + 6 * i + 3] = encodeGain(band.gain);
+            data[2 + 6 * i + 3] = encodeGain(band.gain);
 
             // Write Q-factor (LE)
             uint16_t q          = static_cast<uint16_t>(band.q_factor * 1000);
-            data[1 + 6 * i + 4] = q & 0xFF;
-            data[1 + 6 * i + 5] = (q >> 8) & 0xFF;
+            data[2 + 6 * i + 4] = q & 0xFF;
+            data[2 + 6 * i + 5] = (q >> 8) & 0xFF;
         }
 
         // Fill remaining bands with disabled band
         for (int i = settings.size(); i < EQUALIZER_BANDS; i++) {
             // Disabled frequency
             uint16_t freq       = EQUALIZER_FREQ_DISABLED;
-            data[1 + 6 * i]     = freq & 0xFF;
-            data[1 + 6 * i + 1] = (freq >> 8) & 0xFF;
+            data[2 + 6 * i]     = freq & 0xFF;
+            data[2 + 6 * i + 1] = (freq >> 8) & 0xFF;
 
             // Peaking filter type
-            data[1 + 6 * i + 2] = getFilterByte(EqualizerFilterType::Peaking);
+            data[2 + 6 * i + 2] = getFilterByte(EqualizerFilterType::Peaking);
 
             // Gain = 0
-            data[1 + 6 * i + 3] = 0;
+            data[2 + 6 * i + 3] = 0;
 
             // Default Q-factor: 1.414 * 1000 = 1414 = 0x0586
-            data[1 + 6 * i + 4] = 0x86;
-            data[1 + 6 * i + 5] = 0x05;
+            data[2 + 6 * i + 4] = 0x86;
+            data[2 + 6 * i + 5] = 0x05;
         }
 
-        if (auto result = sendFeatureReport(device_handle, data, MSG_SIZE); !result) {
+        if (auto result = writeHID(device_handle, data, MSG_SIZE); !result) {
             return result.error();
         }
 


### PR DESCRIPTION
### Changes made

Enables Windows support for the SteelSeries Arctis Nova 3P/3X Wireless by switching all device communication from HID **feature reports** to **output reports**, matching the existing Nova 5/7 implementations.

**Why this fixes Windows:** on Windows, hidapi pads feature reports to the interface's declared feature-report length (~1060 bytes on this device), and the firmware silently ignores oversized reports — so every feature-report command was a no-op there. This is the "commands have no effect on Windows" problem observed in #417 when the device was added, which led to the `PLATFORM_LINUX | PLATFORM_MACOS` restriction. Output reports don't hit this issue, so the same packets that already work for the Nova 5/7 work here too.

Details:

- `getBattery()` now uses the shared `readDeviceStatus()` helper (`[0x00, 0xb0]` write + read), like Nova 5/7. The status response layout is identical to the Nova 5: `data[1] == 0x02` → offline, `data[4] == 0x01` → charging, `data[3]` → level percent.
- All commands (sidetone, mic volume, inactive time, equalizer, parametric equalizer, save state) now go through `writeHID()` with the `0x00` report-ID prefix; EQ payload offsets shift by one byte accordingly.
- Adds **charging detection**, which the previous implementation didn't report.
- Removes the `getSupportedPlatforms()` override (base default is `PLATFORM_ALL`) and updates the README row from `L/M` to `All`.

**Tested on real hardware** — Arctis Nova 3X (`0x1038:0x226d`), Windows 11, MSYS2/MinGW64 build:

- Battery level reads correctly (matches an independent node-hid implementation of the same query)
- Charging flag flips when plugging/unplugging the headset
- Sidetone audibly changes across levels
- Equalizer presets audibly change (Flat ↔ Smiley)
- Inactive time accepted without timeout
- Unit tests pass (`ctest`: 2/2)

The byte meanings (`data[4]`: `0x01` charging / `0x03` discharging; `data[1]`: `0x03` online / `0x02` off) were confirmed by live HID captures while docking/undocking the headset.

Note: I could only test on Windows. The write path used here is byte-identical to what the Nova 5/7 already use successfully on Linux/macOS, but a quick Linux/macOS smoke test from another 3P/3X owner would be welcome.

### Checklist

- [x] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself) — N/A, this fixes existing device support rather than adding a feature
