### PR TITLE
Fix MSVC warnings in Corsair Wireless V2 support

### DIFF
--- a/lib/devices/corsair_void_v2w.hpp
+++ b/lib/devices/corsair_void_v2w.hpp
@@ -31,7 +31,7 @@ public:
     static constexpr std::array<uint16_t, 3> SUPPORTED_PRODUCT_IDS {
         0x2a08, // VOID WIRELESS V2 (receiver)
         0x2a02, // VIRTUOSO MAX WIRELESS (receiver)
-        0x0a97  // HS80 MAX Wireless (receiver)
+        0x0a97 // HS80 MAX Wireless (receiver)
     };
 
     std::vector<uint16_t> getProductIds() const override
@@ -99,10 +99,9 @@ public:
         uint16_t battery_level_vendor = static_cast<uint16_t>(battery_response[4] | (battery_response[5] << 8));
 
         const uint16_t battery_level_vendor_max = 1000;
-        const int battery_level_max_attempts = 3;
+        const int battery_level_max_attempts    = 3;
 
-        for (int attempt = 0; attempt < battery_level_max_attempts &&
-             (battery_level_vendor == 0 || battery_level_vendor > battery_level_vendor_max); ++attempt) {
+        for (int attempt = 0; attempt < battery_level_max_attempts && (battery_level_vendor == 0 || battery_level_vendor > battery_level_vendor_max); ++attempt) {
             if (auto result = writeHID(device_handle, battery_request, MSG_SIZE_WRITE); !result) {
                 return result.error();
             }
@@ -122,7 +121,7 @@ public:
             };
         }
 
-        status = BATTERY_AVAILABLE;
+        status    = BATTERY_AVAILABLE;
         int level = static_cast<int>(battery_level_vendor / 10);
 
         // Get the microphone mute state

--- a/lib/devices/corsair_void_v2w.hpp
+++ b/lib/devices/corsair_void_v2w.hpp
@@ -51,7 +51,7 @@ public:
 
     // Override capability as this device needs the interface_id = 4
     constexpr capability_detail
-    getCapabilityDetail(enum capabilities cap) const override
+    getCapabilityDetail([[maybe_unused]] enum capabilities cap) const override
     {
         return { .usagepage = 0, .usageid = 0, .interface_id = 4 };
     }
@@ -158,12 +158,12 @@ public:
         constexpr uint8_t CORSAIR_MIN  = 0;
         constexpr uint16_t CORSAIR_MAX = 1000;
 
-        // Map from 0-128 to 200-255
-        uint16_t mapped_level   = map(level, 0, 128, CORSAIR_MIN, CORSAIR_MAX);
-        uint16_t sidetone_value = round_to_multiples(mapped_level, 10);
-        uint8_t low_byte        = sidetone_value & 0xFF;
-        uint8_t high_byte       = (sidetone_value >> 8) & 0xFF;
-        auto init_result        = initializeDevice(device_handle);
+        // Map from 0-128 to 0-1000
+        uint16_t mapped_level = map<uint16_t>(level, 0, 128, CORSAIR_MIN, CORSAIR_MAX);
+        auto sidetone_value   = round_to_multiples(mapped_level, 10);
+        uint8_t low_byte      = static_cast<uint8_t>(sidetone_value & 0xFF);
+        uint8_t high_byte     = static_cast<uint8_t>((sidetone_value >> 8) & 0xFF);
+        auto init_result      = initializeDevice(device_handle);
         if (init_result.valueOr(0) == 0) {
             return DeviceError::deviceOffline("Headset not connected to wireless receiver");
         }


### PR DESCRIPTION
## Summary

- mark the intentionally unused capability parameter with `[[maybe_unused]]`
- request `uint16_t` output explicitly from `map()`
- retain the unsigned rounding result and explicitly extract its two HID bytes
- correct the sidetone mapping comment to the actual 0-1000 range

This addresses the C4100 and C4244 warnings emitted by MSVC when HeadsetControl is built as a QontrolPanel submodule.

## Validation

- `cmake --build build --target check -j2`
- 2/2 tests passed
- `git diff --check`