### PR TITLE
added support for Virtuoso SE used wired or with receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 | Logitech ASTRO A50 Gen 5 | All | x | x |   | x |   | x |   |   |   |   | x |   |   |   |   |   | x |   |
 | Corsair Headset Device | All | x | x | x | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Corsair Wireless V2 Headset Device | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Corsair Virtuoso XT/SE | All |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis (1/7X/7P) Wireless | All | x | x |   |   | x |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis (7/Pro) | All | x | x |   | x | x | x |   |   |   |   |   |   |   |   |   |   |   |   |
 | SteelSeries Arctis 9 | All | x | x |   |   | x | x |   |   |   |   |   |   |   |   |   |   |   |   |

--- a/lib/devices/corsair_virtuoso_xt.hpp
+++ b/lib/devices/corsair_virtuoso_xt.hpp
@@ -31,9 +31,11 @@ namespace headsetcontrol {
  */
 class CorsairVirtuosoXT : public CorsairDevice {
 public:
-    static constexpr std::array<uint16_t, 2> SUPPORTED_PRODUCT_IDS {
-        0x0a64, // Wireless receiver
-        0x0a62  // Wired USB
+    static constexpr std::array<uint16_t, 4> SUPPORTED_PRODUCT_IDS {
+        0x0a64, // Wireless receiver (Virtuoso XT)
+        0x0a62, // Wired USB (Virtuoso XT)
+        0x0a3e, // Wireless receiver (Virtuoso SE / Slipstream)
+        0x0a3d  // Wired USB (Virtuoso SE)
     };
 
     std::vector<uint16_t> getProductIds() const override
@@ -43,7 +45,7 @@ public:
 
     std::string_view getDeviceName() const override
     {
-        return "Corsair Virtuoso XT"sv;
+        return "Corsair Virtuoso"sv;
     }
 
     constexpr int getCapabilities() const override

--- a/lib/devices/corsair_virtuoso_xt.hpp
+++ b/lib/devices/corsair_virtuoso_xt.hpp
@@ -11,7 +11,7 @@ using namespace std::string_view_literals;
 namespace headsetcontrol {
 
 /**
- * @brief Corsair Virtuoso XT (Wireless + Wired)
+ * @brief Corsair Virtuoso XT / SE (Wireless + Wired)
  *
  * Protocol reverse-engineered via hidraw probing on Linux.
  *
@@ -26,8 +26,8 @@ namespace headsetcontrol {
  *   [0] = 0x0E
  *   [1] = 0x00 (down), 0x01 (up), 0x02 (fast up)
  *
- * Wireless Product ID: 0x0a64 (receiver)
- * Wired Product ID:    0x0a62
+ * Virtuoso XT - Wireless Product ID: 0x0a64 (receiver), Wired Product ID: 0x0a62
+ * Virtuoso SE - Wireless Product ID: 0x0a3e (receiver), Wired Product ID: 0x0a3d
  */
 class CorsairVirtuosoXT : public CorsairDevice {
 public:
@@ -35,7 +35,7 @@ public:
         0x0a64, // Wireless receiver (Virtuoso XT)
         0x0a62, // Wired USB (Virtuoso XT)
         0x0a3e, // Wireless receiver (Virtuoso SE / Slipstream)
-        0x0a3d  // Wired USB (Virtuoso SE)
+        0x0a3d // Wired USB (Virtuoso SE)
     };
 
     std::vector<uint16_t> getProductIds() const override
@@ -45,7 +45,7 @@ public:
 
     std::string_view getDeviceName() const override
     {
-        return "Corsair Virtuoso"sv;
+        return "Corsair Virtuoso XT/SE"sv;
     }
 
     constexpr int getCapabilities() const override


### PR DESCRIPTION
### Changes made

Added support for the Virtuoso SE headset to lib/devices/corsair_virtuoso_xt.hpp

Battery levels:

```
  sudo ./headsetcontrol -b
Found 2 supported device(s):
 Corsair Virtuoso (CORSAIR VIRTUOSO SE USB Gaming Headset) [0x1b1c:0x0a3d]
Battery:
	Status: BATTERY_AVAILABLE
	Level: 59%
 Corsair Virtuoso (CORSAIR Slipstream Multi-Device Receiver) [0x1b1c:0x0a3e]
Battery:
	Status: BATTERY_AVAILABLE
	Level: 59%
```

Capabilities 
```

 sudo ./headsetcontrol --capabilities
Found 2 supported device(s):
 Corsair Virtuoso (CORSAIR VIRTUOSO SE USB Gaming Headset) [0x1b1c:0x0a3d]
	Capabilities:
	* battery

 Corsair Virtuoso (CORSAIR Slipstream Multi-Device Receiver) [0x1b1c:0x0a3e]
	Capabilities:
	* battery


Hint: Use --help while the device is connected to get a filtered list of parameters
```

this is the first thing I ever used AI for assistance, so hopefully it didn't screw anything else up. 

### Checklist

- [N/A] I adjusted the README (if needed)
- [N/A ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)
