### PR TITLE
corsair: add VIRTUOSO SE LED control via V2W protocol

### DIFF
--- a/lib/devices/corsair_virtuoso_xt.hpp
+++ b/lib/devices/corsair_virtuoso_xt.hpp
@@ -26,15 +26,15 @@ namespace headsetcontrol {
  *   [0] = 0x0E
  *   [1] = 0x00 (down), 0x01 (up), 0x02 (fast up)
  *
- * Virtuoso XT - Wireless Product ID: 0x0a64 (receiver), Wired Product ID: 0x0a62
- * Virtuoso SE - Wireless Product ID: 0x0a3e (receiver), Wired Product ID: 0x0a3d
+ * Wireless Product ID: 0x0a64 (receiver)
+ * Wired Product ID:    0x0a62
+ * Wired SE Product ID: 0x0a3d
  */
 class CorsairVirtuosoXT : public CorsairDevice {
 public:
-    static constexpr std::array<uint16_t, 4> SUPPORTED_PRODUCT_IDS {
+    static constexpr std::array<uint16_t, 3> SUPPORTED_PRODUCT_IDS {
         0x0a64, // Wireless receiver (Virtuoso XT)
         0x0a62, // Wired USB (Virtuoso XT)
-        0x0a3e, // Wireless receiver (Virtuoso SE / Slipstream)
         0x0a3d // Wired USB (Virtuoso SE)
     };
 
@@ -45,7 +45,7 @@ public:
 
     std::string_view getDeviceName() const override
     {
-        return "Corsair Virtuoso XT/SE"sv;
+        return "Corsair Virtuoso XT"sv;
     }
 
     constexpr int getCapabilities() const override

--- a/lib/devices/corsair_void_v2w.hpp
+++ b/lib/devices/corsair_void_v2w.hpp
@@ -28,10 +28,11 @@ namespace headsetcontrol {
  */
 class CorsairVoidV2W : public CorsairDevice {
 public:
-    static constexpr std::array<uint16_t, 3> SUPPORTED_PRODUCT_IDS {
+    static constexpr std::array<uint16_t, 4> SUPPORTED_PRODUCT_IDS {
         0x2a08, // VOID WIRELESS V2 (receiver)
         0x2a02, // VIRTUOSO MAX WIRELESS (receiver)
-        0x0a97 // HS80 MAX Wireless (receiver)
+        0x0a97, // HS80 MAX Wireless (receiver)
+        0x0a3e // VIRTUOSO SE Wireless (receiver)
     };
 
     std::vector<uint16_t> getProductIds() const override
@@ -46,7 +47,7 @@ public:
 
     constexpr int getCapabilities() const override
     {
-        return B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME);
+        return B(CAP_SIDETONE) | B(CAP_BATTERY_STATUS) | B(CAP_INACTIVE_TIME) | B(CAP_LIGHTS);
     }
 
     // Override capability as this device needs the interface_id = 4
@@ -251,6 +252,30 @@ public:
         };
     }
 
+    Result<LightsResult> setLights(hid_device* device_handle, bool on) override
+    {
+        auto init_result = initializeDevice(device_handle);
+        if (init_result.valueOr(0) == 0) {
+            return DeviceError::deviceOffline("Headset not connected to wireless receiver");
+        }
+
+        if (auto result = initLEDs(device_handle); !result) {
+            return result.error();
+        }
+
+        if (on) {
+            if (auto result = setZoneRGB(device_handle, 0xFF, 0xFF, 0xFF); !result) {
+                return result.error();
+            }
+        } else {
+            if (auto result = setZoneRGB(device_handle, 0x00, 0x00, 0x00); !result) {
+                return result.error();
+            }
+        }
+
+        return LightsResult { .enabled = on };
+    }
+
     Result<CapabilityInfo> getCapabilityInfo(enum capabilities cap) override
     {
         auto info = HIDDevice::getCapabilityInfo(cap);
@@ -366,6 +391,36 @@ private:
         std::array<uint8_t, MSG_SIZE_READ> heartbeat_response {};
         auto read_headset_result = readHIDTimeout(device_handle, heartbeat_response, hsc_device_timeout);
         return read_headset_result;
+    }
+
+    Result<void> initLEDs(hid_device* device_handle) const
+    {
+        // Initialize LED endpoint (required before RGB commands)
+        std::array<uint8_t, MSG_SIZE_WRITE> led_init {
+            0x00, 0x02, RECEIVER_ENDPOINT, 0x0d, 0x00, 0x01
+        };
+        if (auto result = writeHID(device_handle, led_init, MSG_SIZE_WRITE); !result) {
+            return result.error();
+        }
+        return flushHIDBuffer(device_handle);
+    }
+
+    Result<void> setZoneRGB(hid_device* device_handle, uint8_t r, uint8_t g, uint8_t b) const
+    {
+        // V2W LED command: [report_id, 0x02, endpoint, 0x06, payload...]
+        // Payload: [0x00, 0x09, 0x00, 0x00, 0x00, R, 0, 0, G, 0, 0, B, 0, 0]
+        // Only logo zone is set; mic and battery zones are zeroed
+        std::array<uint8_t, MSG_SIZE_WRITE> rgb_cmd {
+            0x00, 0x02, RECEIVER_ENDPOINT, 0x06,
+            0x00, 0x09, 0x00, 0x00, 0x00,
+            r, 0x00, 0x00, // R: logo, batt, mic
+            g, 0x00, 0x00, // G: logo, batt, mic
+            b, 0x00, 0x00 // B: logo, batt, mic
+        };
+        if (auto result = writeHID(device_handle, rgb_cmd, MSG_SIZE_WRITE); !result) {
+            return result.error();
+        }
+        return flushHIDBuffer(device_handle);
     }
 
     Result<void> flushHIDBuffer(hid_device* device_handle) const


### PR DESCRIPTION
## What

Adds LED on/off control for the Corsair VIRTUOSO SE wireless headset by extending the existing V2W device class with the V2W lighting commands.

## Why

The VIRTUOSO SE was recently added to the V2W class for battery support (#567), but the headset also has a logo LED that users have no way to control from Linux. Issues #252 and #528 both requested SE support and went stale before anyone could reverse engineer the LED protocol.

The standard Corsair headset light command (`C8 00`/`C8 01`) does not work on the VIRTUOSO family. The VIRTUOSO uses the V2W protocol for all HID communication, including lighting. This PR uses the V2W command set (init via command `0x0d`, RGB via command `0x06`) that was documented through reverse engineering efforts by gravityfargo and the VirtuosoControl project.

## Changes

`lib/devices/corsair_void_v2w.hpp`:
- Added `0x0a3e` (VIRTUOSO SE wireless receiver) to `SUPPORTED_PRODUCT_IDS`
- Added `CAP_LIGHTS` to capabilities
- Added `setLights()` method that initializes the LED endpoint then sets all zones to white (on) or zeroed (off)
- Added `initLEDs()` and `setZoneRGB()` private helpers for V2W LED commands

## Testing

Verified on a real Corsair VIRTUOSO SE (PID `0x1b1c:0x0a3e`):
- Battery reads correctly and drains over time
- Lights toggle on/off reliably via `headsetcontrol -l 1` / `-l 0`
- Sidetone works (pre-existing V2W functionality)
- Unit tests pass (CLI test failures are pre-existing on master)