### PR TITLE
Fix -d device selection silently matching nothing for bare hex USB IDs

### DIFF
--- a/cli/dev.cpp
+++ b/cli/dev.cpp
@@ -212,10 +212,10 @@ struct DevOptions {
     for (int c; (c = getopt_long(argc, argv, "d:i:lu:s:m:f:rg:t:hR:", long_opts.data(), &option_index)) != -1;) {
         switch (c) {
         case 'd': {
-            auto ids = headsetcontrol::parse_two_ids(optarg);
+            auto ids = headsetcontrol::parse_two_ids(optarg, 16);
             if (!ids || !in_range(ids->first, 1, 65535) || !in_range(ids->second, 1, 65535)) {
-                std::cerr << "Invalid --device. Use format: VENDORID:PRODUCTID (1-65535 or 0x1-0xffff)\n"
-                          << "  Example: --device 0x1b1c:0x1b27\n";
+                std::cerr << "Invalid --device. Use format: VENDORID:PRODUCTID (hex, 1-ffff)\n"
+                          << "  Example: --device 1b1c:1b27\n";
                 return std::nullopt;
             }
             opts.vendorid  = static_cast<uint16_t>(ids->first);

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -191,9 +191,18 @@ std::optional<cli::ParseError> configureParser(cli::ArgumentParser& parser, Opti
         .custom('d', "device", cli::ArgRequirement::Required, [&opts](std::optional<std::string_view> arg) -> std::optional<cli::ParseError> {
                 if (!arg)
                     return cli::ParseError { "requires vendor:product", "device" };
-                auto ids = headsetcontrol::parse_two_ids(*arg);
+                // USB IDs are hex, and are written without a 0x prefix by lsusb
+                // and by our own device listing.
+                auto ids = headsetcontrol::parse_two_ids(*arg, 16);
                 if (!ids) {
                     return cli::ParseError { "format: vendorid:productid", "device" };
+                }
+                // Narrowing an out-of-range ID would wrap it, and a wrapped-to-zero
+                // ID reads as "no filter" - so -d 10000:10000 would silently match
+                // every device instead of none.
+                constexpr int id_max = 0xffff;
+                if (ids->first < 0 || ids->first > id_max || ids->second < 0 || ids->second > id_max) {
+                    return cli::ParseError { "ids must be between 0 and ffff", "device" };
                 }
                 opts.vendor_id = static_cast<uint16_t>(ids->first);
                 opts.product_id = static_cast<uint16_t>(ids->second);

--- a/lib/utility.cpp
+++ b/lib/utility.cpp
@@ -180,7 +180,7 @@ std::vector<float> parse_float_data(std::string_view input)
     return result;
 }
 
-std::optional<std::pair<int, int>> parse_two_ids(std::string_view input)
+std::optional<std::pair<int, int>> parse_two_ids(std::string_view input, int default_base)
 {
     constexpr std::string_view delimiters = " :.,";
 
@@ -200,19 +200,23 @@ std::optional<std::pair<int, int>> parse_two_ids(std::string_view input)
 
         std::string_view token = input.substr(pos, end - pos);
 
-        // Parse the value (supports hex with 0x prefix)
-        long val = 0;
+        // An explicit prefix always wins; otherwise the caller decides how a bare
+        // token is read, because a USB ID means something different to a decimal.
+        int base = default_base;
         if (token.starts_with("0x") || token.starts_with("0X")) {
-            auto [ptr, ec] = std::from_chars(token.data() + 2, token.data() + token.size(), val, 16);
-            if (ec == std::errc()) {
-                values.push_back(val);
-            }
-        } else {
-            auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), val, 10);
-            if (ec == std::errc()) {
-                values.push_back(val);
-            }
+            token.remove_prefix(2);
+            base = 16;
         }
+
+        long val       = 0;
+        auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), val, base);
+
+        // The whole token has to be a number. Accepting a partial parse is how
+        // "1b1c" read as decimal turns into 1 and quietly selects nothing.
+        if (ec != std::errc() || ptr != token.data() + token.size()) {
+            return std::nullopt;
+        }
+        values.push_back(val);
 
         pos = end;
     }

--- a/lib/utility.hpp
+++ b/lib/utility.hpp
@@ -87,10 +87,19 @@ ParametricEqualizerSettings parse_parametric_equalizer_settings(std::string_view
 /**
  * @brief Parse two IDs from a string like "123:456" or "0x1b1c:0x1b27"
  *
+ * A token carrying an explicit 0x prefix is always read as hexadecimal. Bare
+ * tokens are read in @p default_base, so callers parsing USB vendor and product
+ * IDs should pass 16: those are conventionally written unprefixed in hex, which
+ * is how lsusb and this tool's own device listing print them.
+ *
+ * A token that is only partly numeric is rejected rather than truncated - read
+ * as decimal, "1b1c" would otherwise silently become 1.
+ *
  * @param input string to parse
+ * @param default_base base for tokens without a 0x prefix
  * @return pair of IDs if successful, nullopt otherwise
  */
-std::optional<std::pair<int, int>> parse_two_ids(std::string_view input);
+std::optional<std::pair<int, int>> parse_two_ids(std::string_view input, int default_base = 10);
 
 /**
  * @brief Cross-platform sleep for milliseconds

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -468,6 +468,33 @@ void testParseTwoIds()
     auto empty = parse_two_ids("");
     ASSERT_FALSE(empty.has_value(), "Empty string should fail");
 
+    // A token that is only partly numeric must be rejected, not truncated
+    auto partial = parse_two_ids("1b1c:0a64");
+    ASSERT_FALSE(partial.has_value(), "Bare hex should not parse as decimal");
+
+    // Bare hex, as lsusb and our own device listing print USB IDs
+    auto bare_hex = parse_two_ids("1b1c:0a64", 16);
+    ASSERT_TRUE(bare_hex.has_value(), "Should parse bare hex in base 16");
+    ASSERT_EQ(0x1b1c, bare_hex->first, "First ID should be 0x1b1c");
+    ASSERT_EQ(0x0a64, bare_hex->second, "Second ID should be 0x0a64");
+
+    // An explicit prefix still wins over the requested base
+    auto prefixed = parse_two_ids("0x1b1c:0x0a64", 16);
+    ASSERT_TRUE(prefixed.has_value(), "Prefixed hex should parse in base 16");
+    ASSERT_EQ(0x1b1c, prefixed->first, "First ID should be 0x1b1c");
+
+    // Digits that are decimal in base 10 and hex in base 16
+    auto as_decimal = parse_two_ids("1038:1234");
+    ASSERT_TRUE(as_decimal.has_value(), "Digits should parse as decimal by default");
+    ASSERT_EQ(1038, as_decimal->first, "Base 10 by default");
+    auto as_hex = parse_two_ids("1038:1234", 16);
+    ASSERT_TRUE(as_hex.has_value(), "Digits should parse as hex when asked");
+    ASSERT_EQ(0x1038, as_hex->first, "Base 16 when requested");
+
+    // Not a number in either base
+    auto garbage = parse_two_ids("zz:yy", 16);
+    ASSERT_FALSE(garbage.has_value(), "Non-numeric should fail in base 16 too");
+
     std::cout << "    ✓ parse_two_ids works correctly" << std::endl;
 }
 


### PR DESCRIPTION
### Changes made

`-d 1b1c:0a64` selects nothing:

```console
$ headsetcontrol -b
 Corsair Virtuoso XT/SE (CORSAIR VIRTUOSO XT Wireless Gaming Receiver) [0x1b1c:0x0a64]
Battery:
	Level: 59%

$ headsetcontrol -d 1b1c:0a64 -b
No supported device found
```

`parse_two_ids()` reads a token without a `0x` prefix as decimal, and `std::from_chars` reports success when it consumes only *part* of the input. `"1b1c"` therefore stops at the `b` and yields `1`, `"0a64"` yields `0`. The filter then looks for device `0001:0000`, matches nothing, and the failure surfaces as "No supported device found" — as though the device were unplugged.

The help text has advertised exactly this form all along:

```
  -d, --device VID:PID              Select device (e.g., 1038:12ad)
```

`12ad` cannot be anything but hex, so the documented example could never have worked.

**Fix.** `parse_two_ids()` gains a base for tokens without a `0x` prefix, defaulting to 10 so existing callers are unaffected. The two call sites that parse USB vendor/product IDs — `-d` in `main.cpp` and `--device` in `dev.cpp` — ask for base 16, which is how `lsusb` and this tool's own device listing print them. An explicit `0x` prefix still forces hex regardless of the base, so `-d 0x1b1c:0x0a64` keeps working.

`--usage` in dev mode is *not* a USB ID and its help documents a decimal range (`USAGEPAGE:USAGEID (0-65535)`), so it keeps the decimal default — that's why this is a per-call-site base rather than a global switch.

Partial parses are also rejected outright now instead of being truncated, so a genuinely malformed value reports a format error rather than quietly becoming a filter that matches nothing.

**Range checking** (added after review). `-d` cast the parsed IDs straight to `uint16_t`. An out-of-range value wraps to `0`, and `matchesDevice()` treats `0` as "no filter", so `-d 10000:0a64` matched a device from *any* vendor and `-d 10000:10000` disabled filtering entirely and matched everything connected. Both are now rejected. `0` itself stays accepted, since that is the existing "no filter" default and `-d 1b1c:0` is a legitimate way to select any product from one vendor. Dev mode already range-checked its own `--device`.

### Behaviour change to be aware of

`-d 1234:5678` previously meant decimal `(1234, 5678)` and now means `(0x1234, 0x5678)`. I think that's the correct reading for a USB ID — decimal USB IDs aren't a thing anyone writes, and the flag's own help documents hex — but it is a change, so flagging it explicitly. If you'd rather not touch it, the conservative subset of this PR is just the partial-parse rejection plus the range check, which turns the silent failures into clear errors without reinterpreting anything; happy to trim it down to that.

### Testing

```console
$ headsetcontrol -d 1b1c:0a64 -b        # was: No supported device found
	Level: 59%
$ headsetcontrol -d 0x1b1c:0x0a64 -b    # unchanged
	Level: 59%
$ headsetcontrol -d 1038:12ad -b        # device not present, correctly filtered
No supported device found
$ headsetcontrol -d ffff:ffff -b        # in range, just not present
No supported device found
$ headsetcontrol -d zz:yy -b            # was: No supported device found
Error: device: format: vendorid:productid
$ headsetcontrol -d 10000:0a64 -b       # was: matched a Corsair device
Error: device: ids must be between 0 and ffff
$ headsetcontrol -d 10000:10000 -b      # was: matched everything
Error: device: ids must be between 0 and ffff
$ headsetcontrol --dev -- --device 1b1c:0a64 --list
Device Found
  VendorID:  0x1b1c
  ProductID: 0x0a64
  ...
```

Extended `testParseTwoIds` to cover bare hex in base 16, the `0x` prefix overriding the requested base, the same digits parsing differently in base 10 vs 16, and rejection of partly-numeric and non-numeric tokens. Existing assertions — including `"1234:5678"` → `(1234, 5678)` in the default base — are unchanged and still pass. Full unit suite green, `clang-format` 18 clean.

### Checklist

- [ ] I adjusted the README (if needed)
- [ ] For new features in HeadsetControl: I discussed it beforehand in Issues or Discussions and adhered to the [wiki](https://github.com/Sapd/HeadsetControl/wiki/Development#adding-a-new-feature-to-the-headsestcontrol-application-itself)

Bug fix rather than a new feature, and no README change needed — the documented syntax now behaves as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHCVMmAAeV5WGP7oYZsk3T
